### PR TITLE
fix: use `html/template` instead `text/template` for parse files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- use `html/template` to parse template files (#7)
 
 ## [1.0.3] - 2025-01-01
 ### Changed

--- a/html_template.go
+++ b/html_template.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"io/fs"
 	"strings"
-	"text/template"
+	"html/template"
 
 	"errors"
 )


### PR DESCRIPTION
…iles

Close: https://github.com/yaitoo/xun/issues/6

## Summary by Sourcery

Bug Fixes:
- Fix incorrect usage of `text/template` which caused issues with HTML rendering.