### PR TITLE
feat(html): removed .html file extension limiation

### DIFF
--- a/app.go
+++ b/app.go
@@ -120,7 +120,7 @@ func (app *App) Start() {
 			keys = append(keys, k)
 		}
 
-		app.logger.Info(r.Pattern, slog.String("views", strings.Join(keys, ",")))
+		app.logger.Info(r.Pattern, slog.String("viewer", strings.Join(keys, ",")))
 	}
 
 }

--- a/html_template.go
+++ b/html_template.go
@@ -49,6 +49,9 @@ func (t *HtmlTemplate) Load(fsys fs.FS, templates map[string]*HtmlTemplate) erro
 		return err
 	}
 
+	charset := "; charset=utf-8"
+	mt := "text/html"
+
 	nt := template.New(t.name).Funcs(FuncMap)
 
 	dependencies := make(map[string]struct{})
@@ -58,16 +61,14 @@ func (t *HtmlTemplate) Load(fsys fs.FS, templates map[string]*HtmlTemplate) erro
 		t.dependencies = dependencies
 
 		// text/html; charset=utf-8
-		i := strings.Index(t.mime, ";")
+		i := strings.Index(mt, ";")
 		if i > -1 {
-			t.charset = t.mime[i:]
-			t.mime = t.mime[:i]
+			charset = mt[i:]
+			mt = mt[:i]
 		}
 
-		if t.mime == "" {
-			t.charset = ""
-			t.mime = "application/octet-stream"
-		}
+		t.charset = charset
+		t.mime = mt
 
 	}()
 
@@ -75,10 +76,10 @@ func (t *HtmlTemplate) Load(fsys fs.FS, templates map[string]*HtmlTemplate) erro
 		return nil
 	}
 
-	t.mime = mime.TypeByExtension(filepath.Ext(t.path))
+	mt = mime.TypeByExtension(filepath.Ext(t.path))
 
-	if t.mime == "" {
-		t.mime = http.DetectContentType(buf)
+	if mt == "" {
+		mt = http.DetectContentType(buf)
 	}
 
 	nt, err = nt.Parse(string(buf))

--- a/viewer_html.go
+++ b/viewer_html.go
@@ -28,8 +28,8 @@ type HtmlViewer struct {
 // MimeType returns the MIME type of the HTML content.
 //
 // This implementation returns "text/html".
-func (*HtmlViewer) MimeType() string {
-	return "text/html"
+func (v *HtmlViewer) MimeType() string {
+	return v.template.mime
 }
 
 // Render renders the template with the given data and writes the result to the http.ResponseWriter.
@@ -37,7 +37,7 @@ func (*HtmlViewer) MimeType() string {
 // This implementation uses the `HtmlTemplate.Execute` method to render the template.
 // The rendered result is written to the http.ResponseWriter.
 func (v *HtmlViewer) Render(w http.ResponseWriter, r *http.Request, data any) error { //skipcq: RVV-B0012
-	w.Header().Add("Content-Type", "text/html; charset=utf-8")
+	w.Header().Add("Content-Type", v.template.mime)
 	buf := BufPool.Get()
 	defer BufPool.Put(buf)
 

--- a/viewer_html.go
+++ b/viewer_html.go
@@ -37,7 +37,7 @@ func (v *HtmlViewer) MimeType() string {
 // This implementation uses the `HtmlTemplate.Execute` method to render the template.
 // The rendered result is written to the http.ResponseWriter.
 func (v *HtmlViewer) Render(w http.ResponseWriter, r *http.Request, data any) error { //skipcq: RVV-B0012
-	w.Header().Add("Content-Type", v.template.mime)
+	w.Header().Add("Content-Type", v.template.mime+v.template.charset)
 	buf := BufPool.Get()
 	defer BufPool.Put(buf)
 


### PR DESCRIPTION
### Changed
- fixed #20 : removed .html file extension limitation.

### Fixed
-

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Remove the ".html" file extension limitation for HTML templates.

New Features:
- Allow specifying the MIME type and charset for HTML templates via the `http.DetectContentType` function.

Enhancements:
- Support HTML templates with any file extension.