### PR TITLE
feat(text): add TextViewEngine/TextViewer

### DIFF
--- a/app.go
+++ b/app.go
@@ -73,6 +73,7 @@ func New(opts ...Option) *App {
 		app.viewEngines = []ViewEngine{
 			&StaticViewEngine{},
 			&HtmlViewEngine{},
+			&TextViewEngine{},
 		}
 	}
 

--- a/app.go
+++ b/app.go
@@ -121,7 +121,7 @@ func (app *App) Start() {
 			keys = append(keys, k)
 		}
 
-		app.logger.Info(r.Pattern, slog.String("views", strings.Join(keys, ",")))
+		app.logger.Info(r.Pattern, slog.String("viewer", strings.Join(keys, ",")))
 	}
 
 }

--- a/app_test.go
+++ b/app_test.go
@@ -731,7 +731,7 @@ func TestDataBindOnHtml(t *testing.T) {
 		},
 	}
 
-	FuncMap["ToUpper"] = strings.ToUpper
+	HtmlFuncMap["ToUpper"] = strings.ToUpper
 
 	mux := http.NewServeMux()
 	srv := httptest.NewServer(mux)

--- a/app_test.go
+++ b/app_test.go
@@ -731,7 +731,7 @@ func TestDataBindOnHtml(t *testing.T) {
 		},
 	}
 
-	HtmlFuncMap["ToUpper"] = strings.ToUpper
+	FuncMap["ToUpper"] = strings.ToUpper
 
 	mux := http.NewServeMux()
 	srv := httptest.NewServer(mux)

--- a/app_test.go
+++ b/app_test.go
@@ -26,7 +26,7 @@ var (
 func TestMain(m *testing.M) {
 	tr := http.DefaultTransport.(*http.Transport).Clone()
 	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) { //skipcq: RVV-B0012
+	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) { // skipcq: RVV-B0012
 		if strings.HasPrefix(addr, "abc.com") {
 			return net.Dial("tcp", strings.TrimPrefix(addr, "abc.com"))
 		}
@@ -214,7 +214,7 @@ func TestStatus(t *testing.T) {
 	resp.Body.Close()
 
 	c := http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error { //skipcq: RVV-B0012
+		CheckRedirect: func(req *http.Request, via []*http.Request) error { // skipcq: RVV-B0012
 			return http.ErrUseLastResponse
 		},
 	}
@@ -493,6 +493,8 @@ func TestHtmlViewEngine(t *testing.T) {
 {{ define "content" }}<div>abc.com/index</div>{{ end }}`)},
 		"pages/@abc.com/admin/index.html": {Data: []byte(`<!--layout:admin-->
 {{ define "content" }}<div>abc.com/admin/index</div>{{ end }}`)},
+
+		"pages/empty.html": {},
 	}
 
 	mux := http.NewServeMux()
@@ -593,6 +595,18 @@ func TestHtmlViewEngine(t *testing.T) {
 <div>abc.com/admin/index</div>
 <div>footer</div>
 </body></html>`, string(buf))
+
+	req, err = http.NewRequest("GET", srv.URL+"/empty", nil)
+	req.Header.Set("Accept", "text/html, */*")
+	require.NoError(t, err)
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+
+	buf, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.Empty(t, buf)
 
 }
 

--- a/context.go
+++ b/context.go
@@ -79,7 +79,7 @@ func (c *Context) View(items ...any) error {
 			mime := v.MimeType()
 			ok = false
 			for _, accept := range c.Accept() {
-				if mime == accept {
+				if mime == accept || mime == "*/*" || accept == "*/*" {
 					ok = true
 					break
 				}
@@ -157,8 +157,11 @@ func (c *Context) Accept() (types []string) {
 	types = make([]string, l)
 
 	for i := 0; i < l; i++ {
-		items := strings.SplitN(options[i], ";", 2)
-		types[i] = strings.Trim(items[0], " ")
+		if n := strings.IndexByte(options[i], ';'); n >= 0 {
+			types[i] = strings.TrimSpace(options[i][:n])
+		} else {
+			types[i] = strings.TrimSpace(options[i])
+		}
 	}
 	return
 }

--- a/context.go
+++ b/context.go
@@ -152,6 +152,9 @@ func (c *Context) Accept() (types []string) {
 	if accepted == "" {
 		return
 	}
+
+	// text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
+
 	options := strings.Split(accepted, ",")
 	l := len(options)
 	types = make([]string, l)

--- a/ext/htmx/interceptor.go
+++ b/ext/htmx/interceptor.go
@@ -29,7 +29,7 @@ func (i *interceptor) RequestReferer(c *xun.Context) string {
 	return ""
 }
 
-func (i *interceptor) Redirect(c *xun.Context, url string, statusCode ...int) bool { //skipcq: RVV-B0012
+func (i *interceptor) Redirect(c *xun.Context, url string, statusCode ...int) bool { // skipcq: RVV-B0012
 	if i.IsHxRequest(c) {
 		c.WriteHeader("HX-Redirect", url)
 		c.WriteStatus(http.StatusOK)

--- a/ext/htmx/interceptor_test.go
+++ b/ext/htmx/interceptor_test.go
@@ -30,7 +30,7 @@ func TestHtmxInterceptor(t *testing.T) {
 	defer app.Close()
 
 	client := http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error { //skipcq: RVV-B0012
+		CheckRedirect: func(req *http.Request, via []*http.Request) error { // skipcq: RVV-B0012
 			return http.ErrUseLastResponse
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,12 +14,12 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/gabriel-vasile/mimetype v1.4.7 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	golang.org/x/net v0.33.0 // indirect
+	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gabriel-vasile/mimetype v1.4.7 h1:SKFKl7kD0RiPdbht0s7hFtjl489WcQ1VyPW8ZzUMYCA=
-github.com/gabriel-vasile/mimetype v1.4.7/go.mod h1:GDlAgAyIRT27BhFl53XNAFtfjzOkLaF35JdEG0P7LtU=
+github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
+github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
@@ -34,8 +34,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
 golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=
-golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
-golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
+golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=

--- a/mime.go
+++ b/mime.go
@@ -19,5 +19,4 @@ func GetMimeType(file string, buf []byte) (string, string) {
 		return mt, "; charset=utf-8"
 	}
 	return mt[:i], mt[i:]
-
 }

--- a/mime.go
+++ b/mime.go
@@ -1,0 +1,23 @@
+package xun
+
+import (
+	"mime"
+	"net/http"
+	"path/filepath"
+	"strings"
+)
+
+func GetMimeType(file string, buf []byte) (string, string) {
+	mt := mime.TypeByExtension(filepath.Ext(file))
+	if mt == "" {
+		mt = http.DetectContentType(buf)
+	}
+
+	// text/plain; charset=utf-8
+	i := strings.Index(mt, ";")
+	if i == -1 {
+		return mt, "; charset=utf-8"
+	}
+	return mt[:i], mt[i:]
+
+}

--- a/mime_test.go
+++ b/mime_test.go
@@ -1,0 +1,33 @@
+package xun
+
+import (
+	"mime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMime(t *testing.T) {
+	mime.AddExtensionType(".xun1", "xun/mime; charset=utf-16") // nolint: errcheck
+	mime.AddExtensionType(".xun2", "xun/mime")                 // nolint: errcheck
+
+	t.Run("mime_charset", func(t *testing.T) {
+		mime, charset := GetMimeType("test.xun1", []byte{})
+		require.Equal(t, "xun/mime", mime)
+		require.Equal(t, "; charset=utf-16", charset)
+
+	})
+
+	t.Run("mime_no_charset", func(t *testing.T) {
+		mime, charset := GetMimeType("test.xun2", []byte{})
+		require.Equal(t, "xun/mime", mime)
+		require.Equal(t, "; charset=utf-8", charset)
+
+	})
+
+	t.Run("http_mime", func(t *testing.T) {
+		mime, charset := GetMimeType("test.xun3", []byte(`<?xml version="1.0" encoding="UTF-8"?>`))
+		require.Equal(t, "text/xml", mime)
+		require.Equal(t, "; charset=utf-8", charset)
+	})
+}

--- a/template_html.go
+++ b/template_html.go
@@ -9,8 +9,8 @@ import (
 	"errors"
 )
 
-// HtmlFuncMap is a map of functions that are available to templates.
-var HtmlFuncMap template.FuncMap = make(template.FuncMap)
+// FuncMap is a map of functions that are available to templates.
+var FuncMap template.FuncMap = make(template.FuncMap)
 
 // HtmlTemplate is a template that is loaded from a file system.
 type HtmlTemplate struct {
@@ -44,7 +44,7 @@ func (t *HtmlTemplate) Load(fsys fs.FS, templates map[string]*HtmlTemplate) erro
 		return err
 	}
 
-	nt := template.New(t.name).Funcs(HtmlFuncMap)
+	nt := template.New(t.name).Funcs(FuncMap)
 	dependencies := make(map[string]struct{})
 
 	defer func() {

--- a/template_html.go
+++ b/template_html.go
@@ -9,8 +9,8 @@ import (
 	"errors"
 )
 
-// FuncMap is a map of functions that are available to templates.
-var FuncMap template.FuncMap = make(template.FuncMap)
+// HtmlFuncMap is a map of functions that are available to templates.
+var HtmlFuncMap template.FuncMap = make(template.FuncMap)
 
 // HtmlTemplate is a template that is loaded from a file system.
 type HtmlTemplate struct {
@@ -44,7 +44,7 @@ func (t *HtmlTemplate) Load(fsys fs.FS, templates map[string]*HtmlTemplate) erro
 		return err
 	}
 
-	nt := template.New(t.name).Funcs(FuncMap)
+	nt := template.New(t.name).Funcs(HtmlFuncMap)
 	dependencies := make(map[string]struct{})
 
 	defer func() {

--- a/template_html.go
+++ b/template_html.go
@@ -38,7 +38,7 @@ func NewHtmlTemplate(name, path string) *HtmlTemplate {
 //
 // It parses the file, and determines the dependencies of the template.
 // The dependencies are stored in the `dependencies` field.
-func (t *HtmlTemplate) Load(fsys fs.FS, templates map[string]*HtmlTemplate) error { // skipcp: GO-R1005
+func (t *HtmlTemplate) Load(fsys fs.FS, templates map[string]*HtmlTemplate) error { // skipcq: GO-R1005
 	buf, err := fs.ReadFile(fsys, t.path)
 	if err != nil {
 		return err
@@ -53,6 +53,8 @@ func (t *HtmlTemplate) Load(fsys fs.FS, templates map[string]*HtmlTemplate) erro
 	}()
 
 	if len(buf) == 0 {
+		// fixed err: `template: "?" is an incomplete or empty template
+		nt, _ = nt.Parse("")
 		return nil
 	}
 

--- a/template_html.go
+++ b/template_html.go
@@ -38,7 +38,7 @@ func NewHtmlTemplate(name, path string) *HtmlTemplate {
 //
 // It parses the file, and determines the dependencies of the template.
 // The dependencies are stored in the `dependencies` field.
-func (t *HtmlTemplate) Load(fsys fs.FS, templates map[string]*HtmlTemplate) error {
+func (t *HtmlTemplate) Load(fsys fs.FS, templates map[string]*HtmlTemplate) error { // skipcp: GO-R1005
 	buf, err := fs.ReadFile(fsys, t.path)
 	if err != nil {
 		return err

--- a/template_text.go
+++ b/template_text.go
@@ -43,16 +43,12 @@ func (t *TextTemplate) Load(fsys fs.FS) error {
 	return nil
 }
 
-// Reload reloads the template and all its dependents from the given file system.
+// Reload reloads the template from the given file system.
 func (t *TextTemplate) Reload(fsys fs.FS) error {
-	err := t.Load(fsys)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return t.Load(fsys)
 }
 
+// Execute executes the template with the given data and writes the result to the given writer.
 func (t *TextTemplate) Execute(wr io.Writer, data any) error {
 	return t.template.Execute(wr, data)
 }

--- a/template_text.go
+++ b/template_text.go
@@ -10,13 +10,6 @@ import (
 	"text/template"
 )
 
-// NewTextTemplate creates a new TextTemplate with the given name and path.
-func NewTextTemplate(name string) *TextTemplate {
-	return &TextTemplate{
-		name: name,
-	}
-}
-
 // TextTemplate represents a text template that can be loaded from a file system and executed with data.
 type TextTemplate struct {
 	template *template.Template

--- a/template_text.go
+++ b/template_text.go
@@ -1,0 +1,65 @@
+package xun
+
+import (
+	"io"
+	"io/fs"
+	"text/template"
+)
+
+// TextFuncMap is a template.FuncMap that contains custom functions for use in text templates.
+var TextFuncMap template.FuncMap = make(template.FuncMap)
+
+// NewTextTemplate creates a new TextTemplate with the given name and path.
+func NewTextTemplate(name, path string) *TextTemplate {
+	return &TextTemplate{
+		name: name,
+		path: path,
+	}
+}
+
+// TextTemplate represents a text template that can be loaded from a file system and executed with data.
+type TextTemplate struct {
+	template *template.Template
+
+	name string
+	path string
+}
+
+// Load loads the template from the given file system.
+func (t *TextTemplate) Load(fsys fs.FS, templates map[string]*TextTemplate) error {
+	buf, err := fs.ReadFile(fsys, t.path)
+	if err != nil {
+		return err
+	}
+
+	nt := template.New(t.name).Funcs(TextFuncMap)
+
+	defer func() {
+		t.template = nt
+	}()
+
+	if len(buf) == 0 {
+		return nil
+	}
+
+	nt, err = nt.Parse(string(buf))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Reload reloads the template and all its dependents from the given file system.
+func (t *TextTemplate) Reload(fsys fs.FS, templates map[string]*TextTemplate) error {
+	err := t.Load(fsys, templates)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *TextTemplate) Execute(wr io.Writer, data any) error {
+	return t.template.Execute(wr, data)
+}

--- a/template_text_test.go
+++ b/template_text_test.go
@@ -1,0 +1,36 @@
+package xun
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTextTemplate(t *testing.T) {
+	fsys := &fstest.MapFS{
+		"invalid.txt": {Data: []byte(`{{ define "home" }} {{ define "home" }}{{ end }}`), ModTime: time.Now()},
+	}
+
+	t.Run("fails_cannot_read_file", func(t *testing.T) {
+
+		tmpl := &TextTemplate{
+			name: "foo.txt",
+		}
+
+		err := tmpl.Load(fsys)
+		require.ErrorIs(t, err, fs.ErrNotExist)
+	})
+
+	t.Run("fails_parse_invalid_template", func(t *testing.T) {
+		tmpl := &TextTemplate{
+			name: "invalid.txt",
+		}
+
+		err := tmpl.Load(fsys)
+		require.NotNil(t, err)
+	})
+
+}

--- a/viewengine_html.go
+++ b/viewengine_html.go
@@ -57,7 +57,7 @@ func (ve *HtmlViewEngine) Load(fsys fs.FS, app *App) error {
 // FileChanged is called when a file has been changed.
 //
 // It is used to reload templates when they have been changed.
-func (ve *HtmlViewEngine) FileChanged(fsys fs.FS, app *App, event fsnotify.Event) error { //skipcq: RVV-B0012
+func (ve *HtmlViewEngine) FileChanged(fsys fs.FS, app *App, event fsnotify.Event) error { // skipcq: RVV-B0012
 
 	if event.Has(fsnotify.Remove) || !strings.EqualFold(filepath.Ext(event.Name), ".html") {
 		return nil

--- a/viewengine_text.go
+++ b/viewengine_text.go
@@ -87,7 +87,9 @@ func (ve *TextViewEngine) FileChanged(fsys fs.FS, _ *App, event fsnotify.Event) 
 
 func (ve *TextViewEngine) loadTemplate(path string) (*TextTemplate, error) {
 
-	t := NewTextTemplate(path)
+	t := &TextTemplate{
+		name: path,
+	}
 
 	if err := t.Load(ve.fsys); err != nil {
 		return nil, err

--- a/viewengine_text.go
+++ b/viewengine_text.go
@@ -19,7 +19,6 @@ type TextViewEngine struct {
 // Load walks the file system and loads all text-based templates that match the TextViewEngine's pattern.
 // It calls the handle method for each matching file to add the template to the app's viewers.
 func (ve *TextViewEngine) Load(fsys fs.FS, app *App) error {
-
 	if ve.templates == nil {
 		ve.templates = map[string]*TextTemplate{}
 	}
@@ -63,7 +62,7 @@ func (ve *TextViewEngine) loadText(path string) error {
 // FileChanged is called when a file in the file system has changed. It checks if the change is a
 // file creation event in the "text/" directory, and if so, calls the handle method to update the
 // corresponding view in the app.
-func (ve *TextViewEngine) FileChanged(fsys fs.FS, app *App, event fsnotify.Event) error {
+func (ve *TextViewEngine) FileChanged(fsys fs.FS, app *App, event fsnotify.Event) error { // skipcp: RVV-B0012
 	if event.Has(fsnotify.Remove) {
 		return nil
 	}
@@ -71,7 +70,7 @@ func (ve *TextViewEngine) FileChanged(fsys fs.FS, app *App, event fsnotify.Event
 	if event.Has(fsnotify.Write) {
 		t, ok := ve.templates[event.Name]
 		if ok {
-			return t.Reload(fsys, ve.templates)
+			return t.Reload(fsys)
 		}
 	} else if event.Has(fsnotify.Create) {
 
@@ -90,7 +89,7 @@ func (ve *TextViewEngine) loadTemplate(path string) (*TextTemplate, error) {
 
 	t := NewTextTemplate(path)
 
-	if err := t.Load(ve.fsys, ve.templates); err != nil {
+	if err := t.Load(ve.fsys); err != nil {
 		return nil, err
 	}
 

--- a/viewengine_text.go
+++ b/viewengine_text.go
@@ -62,7 +62,7 @@ func (ve *TextViewEngine) loadText(path string) error {
 // FileChanged is called when a file in the file system has changed. It checks if the change is a
 // file creation event in the "text/" directory, and if so, calls the handle method to update the
 // corresponding view in the app.
-func (ve *TextViewEngine) FileChanged(fsys fs.FS, app *App, event fsnotify.Event) error { // skipcp: RVV-B0012
+func (ve *TextViewEngine) FileChanged(fsys fs.FS, _ *App, event fsnotify.Event) error { // skipcq: RVV-B0012
 	if event.Has(fsnotify.Remove) {
 		return nil
 	}

--- a/viewengine_text.go
+++ b/viewengine_text.go
@@ -1,0 +1,64 @@
+package xun
+
+import (
+	"errors"
+	"io/fs"
+	"path"
+	"strings"
+
+	"github.com/yaitoo/xun/fsnotify"
+)
+
+// TextViewEngine is a view engine that renders text-based templates.
+// It watches the file system for changes to text files and updates the corresponding views.
+type TextViewEngine struct {
+	pattern string
+}
+
+// Load walks the file system and loads all text-based templates that match the TextViewEngine's pattern.
+// It calls the handle method for each matching file to add the template to the app's viewers.
+func (ve *TextViewEngine) Load(fsys fs.FS, app *App) error {
+
+	err := fs.WalkDir(fsys, ".", func(file string, d fs.DirEntry, err error) error {
+		if ok, _ := path.Match(ve.pattern, file); !ok {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() {
+			ve.handle(fsys, app, file)
+		}
+
+		return nil
+	})
+
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+
+	return err
+}
+
+// FileChanged is called when a file in the file system has changed. It checks if the change is a
+// file creation event in the "public/" directory, and if so, calls the handle method to update the
+// corresponding view in the app.
+func (ve *TextViewEngine) FileChanged(fsys fs.FS, app *App, event fsnotify.Event) error {
+	// Nothing should be updated for Write/Remove events.
+	if event.Has(fsnotify.Create) && strings.HasPrefix(event.Name, "public/") {
+		ve.handle(app, event.Name)
+	}
+
+	return nil
+}
+
+func (ßve *TextViewEngine) handle(app *App, path string) {
+
+	name := strings.ToLower(path)
+
+	app.viewers["@text/"+name] = &TextViewer{
+		template: NewTextTemplate(name, path),
+	}
+}

--- a/viewengine_text_test.go
+++ b/viewengine_text_test.go
@@ -99,14 +99,14 @@ func TestWatchOnText(t *testing.T) {
 		return c.View(nil, "text/robots.txt")
 	})
 
-	app.Get("/new.md", func(c *Context) error {
-		return c.View(nil, "text/new.md")
+	app.Get("/new.txt", func(c *Context) error {
+		return c.View(nil, "text/new.txt")
 	})
 
 	app.Start()
 	defer app.Close()
 
-	req, err := http.NewRequest("GET", srv.URL+"/new.md", nil)
+	req, err := http.NewRequest("GET", srv.URL+"/new.txt", nil)
 	require.NoError(t, err)
 	resp, err := client.Do(req)
 	require.NoError(t, err)
@@ -148,7 +148,7 @@ func TestWatchOnText(t *testing.T) {
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>`), ModTime: time.Now()}
 
 	// added
-	fsys["text/new.md"] = &fstest.MapFile{Data: []byte("new content"), ModTime: time.Now()}
+	fsys["text/new.txt"] = &fstest.MapFile{Data: []byte("new content"), ModTime: time.Now()}
 
 	// deleted
 	delete(fsys, "text/robots.txt")
@@ -164,7 +164,7 @@ func TestWatchOnText(t *testing.T) {
 
 	app.watcher.Stop()
 
-	req, err = http.NewRequest("GET", srv.URL+"/new.md", nil)
+	req, err = http.NewRequest("GET", srv.URL+"/new.txt", nil)
 	req.Header.Set("Accept", "text/plain")
 	require.NoError(t, err)
 	resp, err = client.Do(req)
@@ -174,7 +174,7 @@ func TestWatchOnText(t *testing.T) {
 	require.NoError(t, err)
 	resp.Body.Close()
 
-	require.Equal(t, fsys["text/new.md"].Data, buf)
+	require.Equal(t, fsys["text/new.txt"].Data, buf)
 
 	req, err = http.NewRequest("GET", srv.URL+"/sitemap.xml", nil)
 	req.Header.Set("Accept", "application/xml")

--- a/viewengine_text_test.go
+++ b/viewengine_text_test.go
@@ -130,7 +130,7 @@ func TestWatchOnText(t *testing.T) {
 	require.Equal(t, fsys["text/sitemap.xml"].Data, buf)
 
 	req, err = http.NewRequest("GET", srv.URL+"/robots.txt", nil)
-	req.Header.Set("Accept", "text/plain")
+	req.Header.Set("Accept", "text/plain, */*")
 	require.NoError(t, err)
 	resp, err = client.Do(req)
 	require.NoError(t, err)
@@ -165,7 +165,7 @@ func TestWatchOnText(t *testing.T) {
 	app.watcher.Stop()
 
 	req, err = http.NewRequest("GET", srv.URL+"/new.txt", nil)
-	req.Header.Set("Accept", "text/plain")
+	req.Header.Set("Accept", "text/plain, */*")
 	require.NoError(t, err)
 	resp, err = client.Do(req)
 	require.NoError(t, err)
@@ -177,7 +177,7 @@ func TestWatchOnText(t *testing.T) {
 	require.Equal(t, fsys["text/new.txt"].Data, buf)
 
 	req, err = http.NewRequest("GET", srv.URL+"/sitemap.xml", nil)
-	req.Header.Set("Accept", "application/xml")
+	req.Header.Set("Accept", "application/xml,text/xml,text/plain, */*")
 	require.NoError(t, err)
 	resp, err = client.Do(req)
 	require.NoError(t, err)
@@ -190,7 +190,7 @@ func TestWatchOnText(t *testing.T) {
 
 	// deleted not be handled, robots.txt still be there
 	req, err = http.NewRequest("GET", srv.URL+"/robots.txt", nil)
-	req.Header.Set("Accept", "text/plain")
+	req.Header.Set("Accept", "text/plain, */*")
 	require.NoError(t, err)
 	resp, err = client.Do(req)
 	require.NoError(t, err)

--- a/viewengine_text_test.go
+++ b/viewengine_text_test.go
@@ -1,0 +1,205 @@
+package xun
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaitoo/xun/fsnotify"
+)
+
+func TestTextViewEngine(t *testing.T) {
+
+	fsys := fstest.MapFS{
+		"text/sitemap.xml": {Data: []byte(`<?xml version="1.0" encoding="UTF-8"?>`)},
+		"text/robots.txt":  {Data: []byte("User-agent: *")},
+		"text/empty.md":    {},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys))
+
+	app.Get("/sitemap.xml", func(c *Context) error {
+		return c.View(nil, "text/sitemap.xml")
+	})
+
+	app.Get("/robots.txt", func(c *Context) error {
+		return c.View(nil, "text/robots.txt")
+	})
+
+	app.Get("/empty.md", func(c *Context) error {
+		return c.View(nil, "text/empty.md")
+	})
+
+	app.Start()
+	defer app.Close()
+
+	req, err := http.NewRequest("GET", srv.URL+"/sitemap.xml", nil)
+	req.Header.Set("Accept", "application/xml, */*")
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+
+	buf, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.Equal(t, fsys["text/sitemap.xml"].Data, buf)
+
+	req, err = http.NewRequest("GET", srv.URL+"/robots.txt", nil)
+	req.Header.Set("Accept", "text/plain, */*")
+	require.NoError(t, err)
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+
+	buf, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.Equal(t, fsys["text/robots.txt"].Data, buf)
+
+	req, err = http.NewRequest("GET", srv.URL+"/empty.md", nil)
+	req.Header.Set("Accept", "text/plain, */*")
+	require.NoError(t, err)
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+
+	buf, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.Empty(t, buf)
+
+}
+
+func TestWatchOnText(t *testing.T) {
+	fsys := fstest.MapFS{
+		"text/sitemap.xml": {Data: []byte(`<?xml version="1.0" encoding="UTF-8"?>`), ModTime: time.Now()},
+		"text/robots.txt":  {Data: []byte("User-agent: *"), ModTime: time.Now()},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys), WithWatch())
+
+	app.Get("/sitemap.xml", func(c *Context) error {
+		return c.View(nil, "text/sitemap.xml")
+	})
+
+	app.Get("/robots.txt", func(c *Context) error {
+		return c.View(nil, "text/robots.txt")
+	})
+
+	app.Get("/new.md", func(c *Context) error {
+		return c.View(nil, "text/new.md")
+	})
+
+	app.Start()
+	defer app.Close()
+
+	req, err := http.NewRequest("GET", srv.URL+"/new.md", nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+
+	var content string
+	err = json.NewDecoder(resp.Body).Decode(&content)
+	require.NoError(t, err)
+	require.Empty(t, content)
+	resp.Body.Close()
+
+	req, err = http.NewRequest("GET", srv.URL+"/sitemap.xml", nil)
+	req.Header.Set("Accept", "application/xml")
+	require.NoError(t, err)
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+
+	buf, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.Equal(t, fsys["text/sitemap.xml"].Data, buf)
+
+	req, err = http.NewRequest("GET", srv.URL+"/robots.txt", nil)
+	req.Header.Set("Accept", "text/plain")
+	require.NoError(t, err)
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+
+	buf, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.Equal(t, fsys["text/robots.txt"].Data, buf)
+
+	// fixed data race issue on fstest.MapFile
+	app.watcher.Stop()
+
+	fsys["text/sitemap.xml"] = &fstest.MapFile{Data: []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>`), ModTime: time.Now()}
+
+	// added
+	fsys["text/new.md"] = &fstest.MapFile{Data: []byte("new content"), ModTime: time.Now()}
+
+	// deleted
+	delete(fsys, "text/robots.txt")
+
+	checkInterval := fsnotify.CheckInterval
+	fsnotify.CheckInterval = 100 * time.Millisecond
+	defer func() {
+		fsnotify.CheckInterval = checkInterval
+	}()
+
+	go app.watcher.Start()
+	time.Sleep(1 * time.Second)
+
+	app.watcher.Stop()
+
+	req, err = http.NewRequest("GET", srv.URL+"/new.md", nil)
+	req.Header.Set("Accept", "text/plain")
+	require.NoError(t, err)
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+
+	buf, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.Equal(t, fsys["text/new.md"].Data, buf)
+
+	req, err = http.NewRequest("GET", srv.URL+"/sitemap.xml", nil)
+	req.Header.Set("Accept", "application/xml")
+	require.NoError(t, err)
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+
+	buf, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.Equal(t, fsys["text/sitemap.xml"].Data, buf)
+
+	// deleted not be handled, robots.txt still be there
+	req, err = http.NewRequest("GET", srv.URL+"/robots.txt", nil)
+	req.Header.Set("Accept", "text/plain")
+	require.NoError(t, err)
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+
+	buf, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, buf, []byte("User-agent: *"))
+
+}

--- a/viewengine_text_test.go
+++ b/viewengine_text_test.go
@@ -177,7 +177,7 @@ func TestWatchOnText(t *testing.T) {
 	require.Equal(t, fsys["text/new.txt"].Data, buf)
 
 	req, err = http.NewRequest("GET", srv.URL+"/sitemap.xml", nil)
-	req.Header.Set("Accept", "application/xml,text/xml,text/plain, */*")
+	req.Header.Set("Accept", "application/xml;q=0.9,text/xml,text/plain;q=0.8, */*")
 	require.NoError(t, err)
 	resp, err = client.Do(req)
 	require.NoError(t, err)

--- a/viewengine_text_test.go
+++ b/viewengine_text_test.go
@@ -42,7 +42,7 @@ func TestTextViewEngine(t *testing.T) {
 	defer app.Close()
 
 	req, err := http.NewRequest("GET", srv.URL+"/sitemap.xml", nil)
-	req.Header.Set("Accept", "application/xml, */*")
+	req.Header.Set("Accept", "application/xml,text/xml,text/plain, */*")
 	require.NoError(t, err)
 	resp, err := client.Do(req)
 	require.NoError(t, err)
@@ -118,7 +118,7 @@ func TestWatchOnText(t *testing.T) {
 	resp.Body.Close()
 
 	req, err = http.NewRequest("GET", srv.URL+"/sitemap.xml", nil)
-	req.Header.Set("Accept", "application/xml")
+	req.Header.Set("Accept", "application/xml,text/xml,text/plain, */*")
 	require.NoError(t, err)
 	resp, err = client.Do(req)
 	require.NoError(t, err)

--- a/viewer_html.go
+++ b/viewer_html.go
@@ -36,7 +36,7 @@ func (*HtmlViewer) MimeType() string {
 //
 // This implementation uses the `HtmlTemplate.Execute` method to render the template.
 // The rendered result is written to the http.ResponseWriter.
-func (v *HtmlViewer) Render(w http.ResponseWriter, r *http.Request, data any) error { //skipcq: RVV-B0012
+func (v *HtmlViewer) Render(w http.ResponseWriter, r *http.Request, data any) error { // skipcq: RVV-B0012
 	w.Header().Add("Content-Type", "text/html; charset=utf-8")
 	buf := BufPool.Get()
 	defer BufPool.Put(buf)

--- a/viewer_text.go
+++ b/viewer_text.go
@@ -17,7 +17,7 @@ func (v *TextViewer) MimeType() string {
 // Render writes the text content rendered by the TextViewer to the provided http.ResponseWriter.
 // It sets the Content-Type header to "text/plain; charset=utf-8" and writes the rendered content to the response.
 // If there is an error executing the template, it is returned.
-func (v *TextViewer) Render(w http.ResponseWriter, r *http.Request, data any) error { //skipcq: RVV-B0012
+func (v *TextViewer) Render(w http.ResponseWriter, r *http.Request, data any) error { // skipcq: RVV-B0012
 	w.Header().Add("Content-Type", v.template.mime+v.template.charset)
 	buf := BufPool.Get()
 	defer BufPool.Put(buf)

--- a/viewer_text.go
+++ b/viewer_text.go
@@ -4,21 +4,21 @@ import (
 	"net/http"
 )
 
-// TextViewer is a struct that holds an HtmlTemplate and is used to render text content.
+// TextViewer is a struct that holds an TextTemplate and is used to render text content.
 type TextViewer struct {
 	template *TextTemplate
 }
 
 // MimeType returns the MIME type for the text content rendered by the TextViewer.
-func (*TextViewer) MimeType() string {
-	return "text/plain"
+func (v *TextViewer) MimeType() string {
+	return v.template.mime
 }
 
 // Render writes the text content rendered by the TextViewer to the provided http.ResponseWriter.
 // It sets the Content-Type header to "text/plain; charset=utf-8" and writes the rendered content to the response.
 // If there is an error executing the template, it is returned.
 func (v *TextViewer) Render(w http.ResponseWriter, r *http.Request, data any) error { //skipcq: RVV-B0012
-	w.Header().Add("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Add("Content-Type", v.template.mime+v.template.charset)
 	buf := BufPool.Get()
 	defer BufPool.Put(buf)
 

--- a/viewer_text.go
+++ b/viewer_text.go
@@ -1,0 +1,32 @@
+package xun
+
+import (
+	"net/http"
+)
+
+// TextViewer is a struct that holds an HtmlTemplate and is used to render text content.
+type TextViewer struct {
+	template *TextTemplate
+}
+
+// MimeType returns the MIME type for the text content rendered by the TextViewer.
+func (*TextViewer) MimeType() string {
+	return "text/plain"
+}
+
+// Render writes the text content rendered by the TextViewer to the provided http.ResponseWriter.
+// It sets the Content-Type header to "text/plain; charset=utf-8" and writes the rendered content to the response.
+// If there is an error executing the template, it is returned.
+func (v *TextViewer) Render(w http.ResponseWriter, r *http.Request, data any) error { //skipcq: RVV-B0012
+	w.Header().Add("Content-Type", "text/plain; charset=utf-8")
+	buf := BufPool.Get()
+	defer BufPool.Put(buf)
+
+	err := v.template.Execute(buf, data)
+	if err != nil {
+		return err
+	}
+
+	_, err = buf.WriteTo(w)
+	return err
+}


### PR DESCRIPTION
### Changed
-

### Fixed
-

### Added
-  fixed #19 : added `TextViewEngine` and `TextViewer`

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Add support for text files as views, allowing them to be rendered directly by the application.  Update the view engine to handle empty templates correctly, preventing errors during rendering.

New Features:
- Added `TextViewEngine` and `TextViewer` to support rendering text files as views.

Tests:
- Added tests for the new text view engine.