### PR TITLE
fix(routing): added WithViewers to overwrite default hanlder's viewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ For examples, below patterns will be generated automatically, and registered in 
 
 
 ### Multiple Viewers
-In our application, a route can support multiple viewers. The response is rendered based on the `Accept` request header. If no viewer matches the `Accept` header, the default viewer is used. The built-in default viewer is `JsonViewer`, but this can be overridden using `xun.WithViewer` when initializing with `xun.New`. For more examples, see the [Tests](app_test.go).
+In our application, a route can support multiple viewers. The response is rendered based on the `Accept` request header. If no viewer matches the `Accept` header, first registered viewer is used. For more examples, see the [Tests](app_test.go).
 
 ```bash
 curl -v http://127.0.0.1

--- a/app_test.go
+++ b/app_test.go
@@ -138,7 +138,7 @@ func TestStatus(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	app := New(WithMux(mux), WithViewer(&JsonViewer{}))
+	app := New(WithMux(mux), WithHandlerViewers(&JsonViewer{}))
 
 	app.Start()
 	defer app.Close()

--- a/context.go
+++ b/context.go
@@ -83,10 +83,6 @@ func (c *Context) View(data any, options ...string) error {
 		v = c.Routing.Viewers[0] // pickup first viewer as default
 	}
 
-	if !c.writtenStatus {
-		c.rw.WriteHeader(http.StatusOK)
-	}
-
 	return v.Render(c.rw, c.req, data)
 }
 

--- a/option.go
+++ b/option.go
@@ -38,11 +38,11 @@ func WithFsys(fsys fs.FS) Option {
 	}
 }
 
-// WithViewer sets the default Viewer for the App.
+// WithHandlerViewers sets the Viewer for a route handler.
 // If not set, it will use JsonViewer.
-func WithViewer(v Viewer) Option {
+func WithHandlerViewers(v ...Viewer) Option {
 	return func(app *App) {
-		app.viewer = v
+		app.handlerViewers = v
 	}
 }
 
@@ -50,7 +50,7 @@ func WithViewer(v Viewer) Option {
 // If not set, it will use the default ViewEngines.
 func WithViewEngines(ve ...ViewEngine) Option {
 	return func(app *App) {
-		app.viewEngines = ve
+		app.engines = ve
 	}
 }
 

--- a/routing_option.go
+++ b/routing_option.go
@@ -3,7 +3,7 @@ package xun
 // RoutingOptions holds metadata and a viewer for routing configuration.
 type RoutingOptions struct {
 	metadata map[string]any
-	viewer   Viewer
+	viewers  []Viewer
 }
 
 // Get returns the value associated with the given name from the routing metadata.
@@ -78,5 +78,12 @@ func WithNavigation(name, icon, access string) RoutingOption {
 		ro.metadata[NavigationName] = name
 		ro.metadata[NavigationIcon] = icon
 		ro.metadata[NavigationAccess] = access
+	}
+}
+
+// WithViewer sets the viewer for the routing options.
+func WithViewer(v ...Viewer) RoutingOption {
+	return func(ro *RoutingOptions) {
+		ro.viewers = v
 	}
 }

--- a/viewer.go
+++ b/viewer.go
@@ -4,6 +4,17 @@ import (
 	"net/http"
 )
 
+// BufPool is a pool of *bytes.Buffer for reuse to reduce memory alloc.
+//
+// It is used by the Viewer to render the content.
+// The pool is created with a size of 100, but you can change it by setting the
+// BufPool variable before creating any Viewer instances.
+var BufPool *BufferPool
+
+func init() {
+	BufPool = NewBufferPool(100)
+}
+
 // Viewer is the interface that wraps the minimum set of methods required for
 // an effective viewer.
 type Viewer interface {

--- a/viewer_html.go
+++ b/viewer_html.go
@@ -4,17 +4,6 @@ import (
 	"net/http"
 )
 
-// BufPool is a pool of *bytes.Buffer for reuse to reduce memory alloc.
-//
-// It is used by the HtmlViewer to render the template.
-// The pool is created with a size of 100, but you can change it by setting the
-// BufPool variable before creating any HtmlViewer instances.
-var BufPool *BufferPool
-
-func init() {
-	BufPool = NewBufferPool(100)
-}
-
 // HtmlViewer is a viewer that renders a html template.
 //
 // It uses the `HtmlTemplate` type to render a template.

--- a/viewer_json.go
+++ b/viewer_json.go
@@ -23,6 +23,15 @@ func (*JsonViewer) MimeType() *MimeType {
 //
 // It sets the Content-Type header to "application/json".
 func (*JsonViewer) Render(w http.ResponseWriter, r *http.Request, data any) error { // skipcq: RVV-B0012
+	buf := BufPool.Get()
+	defer BufPool.Put(buf)
+
+	err := json.NewEncoder(buf).Encode(data)
+	if err != nil {
+		return err
+	}
+
 	w.Header().Add("Content-Type", "application/json")
-	return json.NewEncoder(w).Encode(data)
+	_, err = buf.WriteTo(w)
+	return err
 }

--- a/viewer_json_test.go
+++ b/viewer_json_test.go
@@ -1,0 +1,30 @@
+package xun
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJsonViewerRenderError(t *testing.T) {
+	v := &JsonViewer{}
+
+	data := make(chan int)
+
+	rw := httptest.NewRecorder()
+	rw.Code = -1
+
+	// should get raw error when json.marshal fails, and StatusCode should be written
+	err := v.Render(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil), data)
+	require.Error(t, err)
+	require.Equal(t, "chan int is unsupported type", err.Error())
+
+	require.Equal(t, -1, rw.Code)
+
+	err = v.Render(rw, httptest.NewRequest(http.MethodGet, "/", nil), "")
+	require.NoError(t, err)
+	require.Equal(t, 200, rw.Code)
+
+}

--- a/viewer_xml.go
+++ b/viewer_xml.go
@@ -1,0 +1,37 @@
+package xun
+
+import (
+	"encoding/xml"
+	"net/http"
+)
+
+// XmlViewer is a viewer that writes the given data as xml to the http.ResponseWriter.
+//
+// It sets the Content-Type header to "application/xml".
+type XmlViewer struct {
+}
+
+var XmlViewerMime = &MimeType{Type: "text", SubType: "xml"}
+
+// MimeType returns the MIME type of the xml content.
+//
+// It returns "text/xml".
+func (*XmlViewer) MimeType() *MimeType {
+	return XmlViewerMime
+}
+
+// Render renders the given data as xml to the http.ResponseWriter.
+//
+// It sets the Content-Type header to "text/xml; charset=utf-8".
+func (*XmlViewer) Render(w http.ResponseWriter, r *http.Request, data any) error { // skipcq: RVV-B0012
+	buf := BufPool.Get()
+	defer BufPool.Put(buf)
+
+	err := xml.NewEncoder(buf).Encode(data)
+	if err != nil {
+		return err
+	}
+	w.Header().Add("Content-Type", "text/xml; charset=utf-8")
+	_, err = buf.WriteTo(w)
+	return err
+}

--- a/viewer_xml_test.go
+++ b/viewer_xml_test.go
@@ -1,0 +1,30 @@
+package xun
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestXmlViewerRenderError(t *testing.T) {
+	v := &XmlViewer{}
+
+	data := make(chan int)
+
+	rw := httptest.NewRecorder()
+	rw.Code = -1
+	// should get raw error when xml.marshal fails, and StatusCode should be written
+	err := v.Render(rw, httptest.NewRequest(http.MethodGet, "/", nil), data)
+
+	_, ok := err.(*xml.UnsupportedTypeError)
+	require.True(t, ok)
+	require.Equal(t, -1, rw.Code)
+
+	err = v.Render(rw, httptest.NewRequest(http.MethodGet, "/", nil), "")
+	require.NoError(t, err)
+	require.Equal(t, 200, rw.Code)
+
+}


### PR DESCRIPTION
### Changed
- changed `app.WithViewer` to `app.WithHandlerViewers` to accept multiple default viewers

### Fixed
-

### Added
- added `WithViewers` in RoutingOption to overwrite default handler's viewers
- added `XmlViewer`

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Add support for XML viewer.

New Features:
- Introduce an XML viewer that allows routes to return responses in XML format.

Tests:
- Add tests for the XML viewer.