### PR TITLE
fix(hsts): used Optional pattern in Enable

### DIFF
--- a/ext/hsts/hsts.go
+++ b/ext/hsts/hsts.go
@@ -9,26 +9,25 @@ import (
 	"github.com/yaitoo/xun"
 )
 
+const defaultMaxAge = int64(365 * 24 * time.Hour / time.Second)
+
 // Enable sets the Strict-Transport-Security header with the given maxAge,
 // includeSubdomains and preload values.
 //
 // The Strict-Transport-Security header is used to inform browsers that the site
 // should only be accessed over HTTPS, and that any HTTP requests should be
 // automatically rewritten as HTTPS.
-//
-// maxAge is the maximum age of the header in seconds.
-//
-// includeSubdomains will include all subdomains of the current domain in the
-// header.
-//
-// preload will add the preload directive to the header, which allows the site
-// to be included in the HSTS preload list.
-//
-// The HSTS preload list is a list of sites that are known to be HTTPS-only, and
-// are included in the browser's HSTS list by default. This allows the browser to
-// immediately switch to HTTPS for these sites, without having to wait for the
-// first request to complete.
-func Enable(maxAge time.Duration, includeSubdomains, preload bool) xun.Middleware {
+func Enable(opts ...Option) xun.Middleware {
+	cfg := &Config{
+		MaxAge:            defaultMaxAge,
+		IncludeSubDomains: true,
+		Preload:           true,
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	return func(next xun.HandleFunc) xun.HandleFunc {
 		return func(c *xun.Context) error {
 			r := c.Request()
@@ -36,15 +35,11 @@ func Enable(maxAge time.Duration, includeSubdomains, preload bool) xun.Middlewar
 			if r.TLS == nil && (r.Method == "GET" || r.Method == "HEAD") {
 				target := "https://" + stripPort(r.Host) + r.URL.RequestURI()
 
-				if maxAge <= 0 {
-					maxAge = 365 * 24 * time.Hour
-				}
-
-				v := "max-age=" + strconv.FormatInt(int64(maxAge/time.Second), 10)
-				if includeSubdomains {
+				v := "max-age=" + strconv.FormatInt(cfg.MaxAge, 10)
+				if cfg.IncludeSubDomains {
 					v += "; includeSubDomains"
 				}
-				if preload {
+				if cfg.Preload {
 					v += "; preload"
 				}
 				c.WriteHeader("Strict-Transport-Security", v)

--- a/ext/hsts/hsts.go
+++ b/ext/hsts/hsts.go
@@ -20,8 +20,8 @@ const defaultMaxAge = int64(365 * 24 * time.Hour / time.Second)
 func Enable(opts ...Option) xun.Middleware {
 	cfg := &Config{
 		MaxAge:            defaultMaxAge,
-		IncludeSubDomains: true,
-		Preload:           true,
+		IncludeSubDomains: false,
+		Preload:           false,
 	}
 
 	for _, opt := range opts {

--- a/ext/hsts/hsts_test.go
+++ b/ext/hsts/hsts_test.go
@@ -29,7 +29,7 @@ func TestHstsMiddleware(t *testing.T) {
 		l := "https://" + u.Hostname() + "/"
 		app := xun.New(xun.WithMux(mux))
 
-		app.Use(Enable(1*time.Hour, false, false))
+		app.Use(Enable(WithMaxAge(1*time.Hour), WithDomains(false), WithPreload(false)))
 
 		app.Get("/", func(c *xun.Context) error {
 			return c.View(nil)
@@ -55,7 +55,7 @@ func TestHstsMiddleware(t *testing.T) {
 		l := "https://" + u.Hostname() + "/"
 		app := xun.New(xun.WithMux(mux))
 
-		app.Use(Enable(0*time.Hour, false, false))
+		app.Use(Enable(WithDomains(false), WithPreload(false)))
 
 		app.Get("/", func(c *xun.Context) error {
 			return c.View(nil)
@@ -81,7 +81,7 @@ func TestHstsMiddleware(t *testing.T) {
 		l := "https://" + u.Hostname() + "/"
 		app := xun.New(xun.WithMux(mux))
 
-		app.Use(Enable(1*time.Hour, true, false))
+		app.Use(Enable(WithMaxAge(1*time.Hour), WithDomains(true), WithPreload(false)))
 
 		app.Get("/", func(c *xun.Context) error {
 			return c.View(nil)
@@ -107,7 +107,7 @@ func TestHstsMiddleware(t *testing.T) {
 		l := "https://" + u.Hostname() + "/"
 		app := xun.New(xun.WithMux(mux))
 
-		app.Use(Enable(1*time.Hour, true, true))
+		app.Use(Enable(WithMaxAge(1*time.Hour), WithDomains(true), WithPreload(true)))
 
 		app.Get("/", func(c *xun.Context) error {
 			return c.View(nil)

--- a/ext/hsts/option.go
+++ b/ext/hsts/option.go
@@ -1,0 +1,50 @@
+package hsts
+
+import "time"
+
+// Config represents the configuration options for HSTS (HTTP Strict Transport Security).
+// It includes various settings such as MaxAge, IncludeSubDomains, and Preload.
+type Config struct {
+	MaxAge            int64 // MaxAge specifies the duration for which the HSTS policy is in effect.
+	IncludeSubDomains bool  // IncludeSubDomains indicates whether the HSTS policy applies to subdomains.
+	Preload           bool  // Preload indicates whether the domain should be preloaded into browsers' HSTS lists.
+}
+
+// Option is a function that modifies a Config instance.
+// It is used to configure HSTS settings by applying various options.
+type Option func(c *Config)
+
+// WithMaxAge sets the maximum age for the HSTS policy.
+//
+// The maximum age specifies the duration for which the HSTS policy is in effect.
+// Note that the maximum age is specified in seconds, so "1h" would be equivalent to 3600.
+func WithMaxAge(t time.Duration) Option {
+	return func(c *Config) {
+		if t > 0 {
+			c.MaxAge = int64(t / time.Second)
+		}
+	}
+}
+
+// WithDomains sets whether the HSTS policy applies to subdomains.
+//
+// If true, the policy will also apply to subdomains of the current domain.
+// For example, if the current domain is "example.com", the policy will also
+// apply to subdomains such as "foo.example.com" and "bar.example.com".
+func WithDomains(b bool) Option {
+	return func(c *Config) {
+		c.IncludeSubDomains = b
+	}
+}
+
+// WithPreload sets whether the domain should be preloaded into browsers' HSTS lists.
+//
+// If true, the domain will be added to the preload list, which allows the site
+// to be included in the HSTS preload list. This can help improve the security
+// of the site, as browsers will immediately switch to HTTPS for this domain,
+// without waiting for the first request to complete.
+func WithPreload(b bool) Option {
+	return func(c *Config) {
+		c.Preload = b
+	}
+}


### PR DESCRIPTION
### Changed
- used Optional pattern in `hsts.Enable`

### Fixed
-

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Enhancements:
- Change the `Enable` function signature to accept a variadic number of options.