### PR TITLE
fix(hsts): split hsts into WriteHeader and Redirect

### DIFF
--- a/ext/hsts/hsts.go
+++ b/ext/hsts/hsts.go
@@ -1,3 +1,20 @@
+// Package hsts provides functionality for handling HTTP Strict Transport Security (HSTS).
+//
+// This package includes options and middleware for configuring HSTS headers in HTTP responses.
+// HSTS is a web security policy mechanism that helps protect websites against man-in-the-middle
+// attacks such as protocol downgrade attacks and cookie hijacking.
+//
+// The primary components of this package are:
+// - Config: A struct representing HSTS configuration options like MaxAge, IncludeSubDomains, and Preload.
+// - Option: A function type used to modify a Config instance with different settings.
+// - Middleware: A function to apply HSTS settings to HTTP responses.
+//
+// Example usage:
+//   app := xun.New()
+//   app.Use(hsts.Header(hsts.WithMaxAge(24 * time.Hour), hsts.WithPreload(true)))
+//
+// This would set the HSTS header with a max-age of 1 day and enable preload for the domain.
+
 package hsts
 
 import (
@@ -11,13 +28,8 @@ import (
 
 const defaultMaxAge = int64(365 * 24 * time.Hour / time.Second)
 
-// Enable sets the Strict-Transport-Security header with the given maxAge,
-// includeSubdomains and preload values.
-//
-// The Strict-Transport-Security header is used to inform browsers that the site
-// should only be accessed over HTTPS, and that any HTTP requests should be
-// automatically rewritten as HTTPS.
-func Enable(opts ...Option) xun.Middleware {
+// WriteHeader is a middleware that sets the STS response header for a HTTPs request.
+func WriteHeader(opts ...Option) xun.Middleware {
 	cfg := &Config{
 		MaxAge:            defaultMaxAge,
 		IncludeSubDomains: false,
@@ -32,9 +44,7 @@ func Enable(opts ...Option) xun.Middleware {
 		return func(c *xun.Context) error {
 			r := c.Request()
 
-			if r.TLS == nil && (r.Method == "GET" || r.Method == "HEAD") {
-				target := "https://" + stripPort(r.Host) + r.URL.RequestURI()
-
+			if r.TLS != nil && (r.Method == "GET" || r.Method == "HEAD") {
 				v := "max-age=" + strconv.FormatInt(cfg.MaxAge, 10)
 				if cfg.IncludeSubDomains {
 					v += "; includeSubDomains"
@@ -43,6 +53,25 @@ func Enable(opts ...Option) xun.Middleware {
 					v += "; preload"
 				}
 				c.WriteHeader("Strict-Transport-Security", v)
+			}
+
+			return next(c)
+		}
+	}
+}
+
+// Redirect is a middleware that redirects all plain HTTP requests to HTTPS.
+//
+// This middleware assumes that the request is served over a secure connection.
+// It checks if the request is a GET or a HEAD request and redirects it to the
+// same path but with HTTPS if the request is not served over a secure connection.
+func Redirect() xun.Middleware {
+	return func(next xun.HandleFunc) xun.HandleFunc {
+		return func(c *xun.Context) error {
+			r := c.Request()
+
+			if r.TLS == nil && (r.Method == "GET" || r.Method == "HEAD") {
+				target := "https://" + stripPort(r.Host) + r.URL.RequestURI()
 
 				c.Redirect(target, http.StatusFound)
 				return xun.ErrCancelled

--- a/ext/hsts/hsts.go
+++ b/ext/hsts/hsts.go
@@ -60,11 +60,7 @@ func WriteHeader(opts ...Option) xun.Middleware {
 	}
 }
 
-// Redirect is a middleware that redirects all plain HTTP requests to HTTPS.
-//
-// This middleware assumes that the request is served over a secure connection.
-// It checks if the request is a GET or a HEAD request and redirects it to the
-// same path but with HTTPS if the request is not served over a secure connection.
+// Redirect is a middleware that redirects plain HTTP requests to HTTPS.
 func Redirect() xun.Middleware {
 	return func(next xun.HandleFunc) xun.HandleFunc {
 		return func(c *xun.Context) error {

--- a/ext/hsts/hsts_test.go
+++ b/ext/hsts/hsts_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestWriteHeader(t *testing.T) {
 	tr := http.DefaultTransport.(*http.Transport).Clone()
-	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // skipcq: GSC-G402,GO-S1020
 	c := http.Client{
 		Transport: tr,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error { // skipcq: RVV-B0012
@@ -90,7 +90,7 @@ func TestWriteHeader(t *testing.T) {
 func TestRedirect(t *testing.T) {
 
 	tr := http.DefaultTransport.(*http.Transport).Clone()
-	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // skipcq: GSC-G402,GO-S1020
 	c := http.Client{
 		Transport: tr,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error { // skipcq: RVV-B0012

--- a/ext/hsts/option.go
+++ b/ext/hsts/option.go
@@ -26,25 +26,16 @@ func WithMaxAge(t time.Duration) Option {
 	}
 }
 
-// WithDomains sets whether the HSTS policy applies to subdomains.
-//
-// If true, the policy will also apply to subdomains of the current domain.
-// For example, if the current domain is "example.com", the policy will also
-// apply to subdomains such as "foo.example.com" and "bar.example.com".
-func WithDomains(b bool) Option {
+// WithIncludeSubDomains sets the HSTS policy applies to subdomains.
+func WithIncludeSubDomains() Option {
 	return func(c *Config) {
-		c.IncludeSubDomains = b
+		c.IncludeSubDomains = true
 	}
 }
 
-// WithPreload sets whether the domain should be preloaded into browsers' HSTS lists.
-//
-// If true, the domain will be added to the preload list, which allows the site
-// to be included in the HSTS preload list. This can help improve the security
-// of the site, as browsers will immediately switch to HTTPS for this domain,
-// without waiting for the first request to complete.
-func WithPreload(b bool) Option {
+// WithPreload sets the domain should be preloaded into browsers' HSTS lists.
+func WithPreload() Option {
 	return func(c *Config) {
-		c.Preload = b
+		c.Preload = true
 	}
 }


### PR DESCRIPTION
### Changed
- split `hsts.Enable` into `hsts.Redirect` for http request, and `hsts.WriteHeader` for https request

### Fixed
-

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Split the HSTS middleware into two separate middlewares: `Redirect` and `WriteHeader`. `Redirect` redirects HTTP requests to HTTPS, and `WriteHeader` sets the `Strict-Transport-Security` header for HTTPS requests.

Enhancements:
- Refactor the HSTS middleware to improve clarity and testability.

Tests:
- Add unit tests for the new `Redirect` and `WriteHeader` middlewares.