### PR TITLE
fix(file): fixed Last-Modified/Etag issue on embed file system

### DIFF
--- a/viewengine_static.go
+++ b/viewengine_static.go
@@ -1,6 +1,7 @@
 package xun
 
 import (
+	"embed"
 	"errors"
 	"io/fs"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 // StaticViewEngine is a view engine that serves static files from a file system.
 type StaticViewEngine struct {
+	isEmbedFsys bool
 }
 
 // Load loads all static files from the given file system and registers them with the application.
@@ -18,6 +20,8 @@ type StaticViewEngine struct {
 // with the application. It also handles file changes for the "public" directory
 // and updates the application accordingly.
 func (ve *StaticViewEngine) Load(fsys fs.FS, app *App) error {
+
+	_, ve.isEmbedFsys = fsys.(embed.FS)
 
 	err := fs.WalkDir(fsys, "public", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -65,8 +69,5 @@ func (ve *StaticViewEngine) handle(fsys fs.FS, app *App, path string) {
 
 	name = strings.TrimPrefix(name, "public/")
 
-	app.HandleFile(name, &FileViewer{
-		fsys: fsys,
-		path: path,
-	})
+	app.HandleFile(name, NewFileViewer(fsys, path, ve.isEmbedFsys))
 }

--- a/viewer_file.go
+++ b/viewer_file.go
@@ -1,7 +1,7 @@
 package xun
 
 import (
-	"crypto/md5"
+	"crypto/sha1"
 	"fmt"
 	"io"
 	"io/fs"
@@ -23,7 +23,7 @@ func NewFileViewer(fsys fs.FS, path string, isEmbed bool) *FileViewer {
 		}
 		defer f.Close()
 
-		hash := md5.New()
+		hash := sha1.New()
 		if _, err := io.Copy(hash, f); err != nil {
 			return v
 		}

--- a/viewer_file.go
+++ b/viewer_file.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"strings"
 )
 
 // NewFileViewer creates a new FileViewer instance.
@@ -76,10 +77,13 @@ func (v *FileViewer) Render(w http.ResponseWriter, r *http.Request, data any) er
 
 	w.Header().Set("ETag", v.etag)
 	if match := r.Header.Get("If-None-Match"); match != "" {
-		if match == v.etag {
-			w.WriteHeader(http.StatusNotModified)
-			return nil
+		for _, it := range strings.Split(match, ",") {
+			if strings.TrimSpace(it) == v.etag {
+				w.WriteHeader(http.StatusNotModified)
+				return nil
+			}
 		}
+
 	}
 
 	return v.serveContent(w, r)

--- a/viewer_file.go
+++ b/viewer_file.go
@@ -1,7 +1,7 @@
 package xun
 
 import (
-	"crypto/sha1"
+	"crypto/sha512"
 	"fmt"
 	"io"
 	"io/fs"
@@ -22,7 +22,7 @@ func NewFileViewer(fsys fs.FS, path string, isEmbed bool) *FileViewer {
 		}
 		defer f.Close()
 
-		hash := sha1.New()
+		hash := sha512.New()
 		if _, err := io.Copy(hash, f); err != nil {
 			return v
 		}

--- a/viewer_file.go
+++ b/viewer_file.go
@@ -11,12 +11,11 @@ import (
 // NewFileViewer creates a new FileViewer instance.
 func NewFileViewer(fsys fs.FS, path string, isEmbed bool) *FileViewer {
 	v := &FileViewer{
-		fsys:    fsys,
-		path:    path,
-		isEmbed: isEmbed,
+		fsys: fsys,
+		path: path,
 	}
 
-	if v.isEmbed {
+	if isEmbed {
 		f, err := fsys.Open(path)
 		if err != nil {
 			return v
@@ -27,6 +26,7 @@ func NewFileViewer(fsys fs.FS, path string, isEmbed bool) *FileViewer {
 		if _, err := io.Copy(hash, f); err != nil {
 			return v
 		}
+		v.isEmbed = true
 		v.etag = fmt.Sprintf(`"%x"`, hash.Sum(nil))
 	}
 

--- a/viewer_file_test.go
+++ b/viewer_file_test.go
@@ -1,0 +1,96 @@
+package xun
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileViewer(t *testing.T) {
+	now := time.Now()
+	fsys := &fstest.MapFS{
+		"public/index.html": {Data: []byte(`<!DOCTYPE html><html><body>Hello, world!</body></html>`), ModTime: time.Now()},
+	}
+
+	// https://github.com/yaitoo/xun/issues/32
+	t.Run("etag_should_work_without_mod_time", func(t *testing.T) {
+		v := NewFileViewer(fsys, "public/index.html", true)
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		require.Equal(t, "*/*", v.MimeType().String())
+		err := v.Render(w, r, nil)
+
+		require.NoError(t, err)
+		etag := w.Header().Get("ETag")
+
+		require.Equal(t, v.etag, etag)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		r = httptest.NewRequest(http.MethodGet, "/", nil)
+		r.Header.Add("If-None-Match", etag)
+
+		w = httptest.NewRecorder()
+
+		err = v.Render(w, r, nil)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, etag)
+		require.Equal(t, http.StatusNotModified, w.Code)
+	})
+
+	t.Run("last_modified_should_work", func(t *testing.T) {
+		v := NewFileViewer(fsys, "public/index.html", false)
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		err := v.Render(w, r, nil)
+
+		require.NoError(t, err)
+		lastModified := w.Header().Get("Last-Modified")
+		require.NotEmpty(t, lastModified)
+
+		modTime := now.UTC().Format(http.TimeFormat)
+		require.Equal(t, modTime, lastModified)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		r = httptest.NewRequest(http.MethodGet, "/", nil)
+		r.Header.Add("If-Modified-Since", modTime)
+
+		w = httptest.NewRecorder()
+
+		err = v.Render(w, r, nil)
+		require.NoError(t, err)
+
+		lastModified = w.Header().Get("Last-Modified")
+		require.NotEmpty(t, lastModified)
+
+		require.Equal(t, http.StatusNotModified, w.Code)
+	})
+
+	t.Run("file_not_found_should_work", func(t *testing.T) {
+		v := NewFileViewer(fsys, "public/notfound.html", false)
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		err := v.Render(w, r, nil)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNotFound, w.Code)
+
+		v = NewFileViewer(fsys, "public/notfound.html", true)
+		r = httptest.NewRequest(http.MethodGet, "/", nil)
+		w = httptest.NewRecorder()
+
+		err = v.Render(w, r, nil)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNotFound, w.Code)
+
+	})
+
+}

--- a/viewer_file_test.go
+++ b/viewer_file_test.go
@@ -131,7 +131,7 @@ type MockFs struct {
 	CanStat bool
 }
 
-func (m *MockFs) Open(name string) (fs.File, error) {
+func (m *MockFs) Open(name string) (fs.File, error) { // skipcq: RVV-B0012
 	if m.CanOpen {
 		return &MockFile{
 			CanRead: m.CanRead,
@@ -165,6 +165,6 @@ func (f *MockFile) Read([]byte) (int, error) {
 
 	return 0, errors.New("mock: can't read")
 }
-func (f *MockFile) Close() error {
+func (*MockFile) Close() error {
 	return nil
 }


### PR DESCRIPTION
### Changed
-

### Fixed
- fixed #32 : fixed `Last-Modified/ETag` issue on embed file system.

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where the Last-Modified and ETag headers were not being set correctly for embedded files.