### PR TITLE
fix(static): fixed embed fs checking

### DIFF
--- a/viewengine_static.go
+++ b/viewengine_static.go
@@ -1,9 +1,9 @@
 package xun
 
 import (
-	"embed"
 	"errors"
 	"io/fs"
+	"reflect"
 	"strings"
 
 	"github.com/yaitoo/xun/fsnotify"
@@ -20,10 +20,15 @@ type StaticViewEngine struct {
 // with the application. It also handles file changes for the "public" directory
 // and updates the application accordingly.
 func (ve *StaticViewEngine) Load(fsys fs.FS, app *App) error {
+	root, err := fsys.Open(".")
+	if err == nil {
+		t := reflect.TypeOf(root)
+		if t.Kind() == reflect.Ptr {
+			ve.isEmbedFsys = t.Elem().PkgPath() == "embed"
+		}
+	}
 
-	_, ve.isEmbedFsys = fsys.(embed.FS)
-
-	err := fs.WalkDir(fsys, "public", func(path string, d fs.DirEntry, err error) error {
+	err = fs.WalkDir(fsys, "public", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/viewer_file.go
+++ b/viewer_file.go
@@ -1,7 +1,7 @@
 package xun
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"io"
 	"io/fs"
@@ -23,7 +23,7 @@ func NewFileViewer(fsys fs.FS, path string, isEmbed bool) *FileViewer {
 		}
 		defer f.Close()
 
-		hash := md5.New()
+		hash := sha256.New() // skipcq: GSC-G401, GO-S1023
 		if _, err := io.Copy(hash, f); err != nil {
 			return v
 		}

--- a/viewer_file.go
+++ b/viewer_file.go
@@ -1,8 +1,8 @@
 package xun
 
 import (
-	"crypto/sha512"
-	"fmt"
+	"crypto/md5"
+	"encoding/hex"
 	"io"
 	"io/fs"
 	"net/http"
@@ -23,12 +23,12 @@ func NewFileViewer(fsys fs.FS, path string, isEmbed bool) *FileViewer {
 		}
 		defer f.Close()
 
-		hash := sha512.New()
+		hash := md5.New()
 		if _, err := io.Copy(hash, f); err != nil {
 			return v
 		}
 		v.isEmbed = true
-		v.etag = fmt.Sprintf(`"%x"`, hash.Sum(nil))
+		v.etag = `"` + hex.EncodeToString(hash.Sum(nil)) + `"`
 	}
 
 	return v


### PR DESCRIPTION
### Changed
- used sha256 to generate etag 

### Fixed
- fixed embed fs checking 


### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Fix embed filesystem checking and use MD5 for ETag generation.

Bug Fixes:
- Fixed a bug in embed filesystem checking.

Enhancements:
- Use MD5 instead of SHA512 for ETag generation.