### PR TITLE
fix(context): break match loop when any viewer is matched

### DIFF
--- a/context.go
+++ b/context.go
@@ -77,6 +77,10 @@ func (c *Context) View(data any, options ...string) error {
 					break
 				}
 			}
+
+			if ok {
+				break
+			}
 		}
 	}
 	// no any viewer is matched


### PR DESCRIPTION
### Changed
-

### Fixed
- first matched viewer should be selected immediately .

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Bug Fixes:
- Fixed a bug where the viewer matching loop did not terminate after finding a match.