### PR TITLE
fix(context): throw ErrViewNotFound when no view is avaiable

### DIFF
--- a/app.go
+++ b/app.go
@@ -233,6 +233,12 @@ func (app *App) HandleFile(name string, v *FileViewer) {
 			return
 		}
 
+		if errors.Is(err, ErrViewNotFound) {
+			ctx.WriteStatus(http.StatusNotFound)
+			ctx.Response.Write([]byte("View Not Found")) // nolint: errcheck
+			return
+		}
+
 		logID := nextLogID()
 		ctx.WriteHeader("X-Log-Id", logID)
 		ctx.WriteStatus(http.StatusInternalServerError)

--- a/app.go
+++ b/app.go
@@ -233,12 +233,6 @@ func (app *App) HandleFile(name string, v *FileViewer) {
 			return
 		}
 
-		if errors.Is(err, ErrViewNotFound) {
-			ctx.WriteStatus(http.StatusNotFound)
-			ctx.Response.Write([]byte("View Not Found")) // nolint: errcheck
-			return
-		}
-
 		logID := nextLogID()
 		ctx.WriteHeader("X-Log-Id", logID)
 		ctx.WriteStatus(http.StatusInternalServerError)
@@ -392,6 +386,12 @@ func (app *App) createHandler(pattern string, hf HandleFunc, opts []RoutingOptio
 		err := r.Next(ctx)
 
 		if err == nil || errors.Is(err, ErrCancelled) {
+			return
+		}
+
+		if errors.Is(err, ErrViewNotFound) {
+			ctx.WriteStatus(http.StatusNotFound)
+			ctx.Response.Write([]byte("View Not Found")) // nolint: errcheck
 			return
 		}
 

--- a/context.go
+++ b/context.go
@@ -74,6 +74,9 @@ func (c *Context) View(data any, options ...string) error {
 	// no any viewer is matched
 	if !ok {
 		if v == nil {
+			if len(c.Routing.Viewers) == 0 {
+				return ErrViewNotFound
+			}
 			v = c.Routing.Viewers[0] // use the first viewer as a fallback when no viewer is matched or specified by name
 		}
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -112,6 +112,10 @@ func TestMixedViewers(t *testing.T) {
 		})
 	})
 
+	app.Get("/view404", func(c *Context) error {
+		return c.View(nil)
+	}, WithViewer()) //deleted default viewer
+
 	app.Start()
 	defer app.Close()
 
@@ -132,6 +136,16 @@ func TestMixedViewers(t *testing.T) {
 
 	t.Run("not_found_should_be_used", func(t *testing.T) {
 		req, err := http.NewRequest("GET", srv.URL+"/404", nil)
+		req.Header.Set("Accept", "text/html")
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+		resp.Body.Close()
+	})
+
+	t.Run("view_not_found", func(t *testing.T) {
+		req, err := http.NewRequest("GET", srv.URL+"/view404", nil)
 		req.Header.Set("Accept", "text/html")
 		require.NoError(t, err)
 		resp, err := client.Do(req)

--- a/context_test.go
+++ b/context_test.go
@@ -114,7 +114,7 @@ func TestMixedViewers(t *testing.T) {
 
 	app.Get("/view404", func(c *Context) error {
 		return c.View(nil)
-	}, WithViewer()) //deleted default viewer
+	}, WithViewer()) // delete default viewer
 
 	app.Start()
 	defer app.Close()

--- a/errs.go
+++ b/errs.go
@@ -3,5 +3,6 @@ package xun
 import "errors"
 
 var (
-	ErrCancelled = errors.New("xun: request_cancelled")
+	ErrCancelled    = errors.New("xun: request_cancelled")
+	ErrViewNotFound = errors.New("xun: view_not_found")
 )


### PR DESCRIPTION
### Changed
-

### Fixed
- fixe panic when no any view is avaiable.

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Bug Fixes:
- Fixed a panic that occurred when no view was available.