### PR TITLE
fix(context): exposed StatusCode

### DIFF
--- a/app.go
+++ b/app.go
@@ -222,7 +222,7 @@ func (app *App) HandleFile(name string, v *FileViewer) {
 
 		ctx := &Context{
 			Request:  req,
-			Response: NewResponseWriter(rw),
+			Response: rw,
 			Routing:  *r,
 			app:      app,
 		}
@@ -280,7 +280,7 @@ func (app *App) HandlePage(pattern string, viewName string, v Viewer) {
 
 		ctx := &Context{
 			Request:  req,
-			Response: NewResponseWriter(rw),
+			Response: rw,
 			Routing:  *r,
 			app:      app,
 		}
@@ -378,7 +378,7 @@ func (app *App) createHandler(pattern string, hf HandleFunc, opts []RoutingOptio
 
 		ctx := &Context{
 			Request:  req,
-			Response: NewResponseWriter(rw),
+			Response: rw,
 			Routing:  *r,
 			app:      app,
 		}

--- a/app.go
+++ b/app.go
@@ -222,7 +222,7 @@ func (app *App) HandleFile(name string, v *FileViewer) {
 
 		ctx := &Context{
 			Request:  req,
-			Response: rw,
+			Response: NewResponseWriter(rw),
 			Routing:  *r,
 			app:      app,
 		}
@@ -280,7 +280,7 @@ func (app *App) HandlePage(pattern string, viewName string, v Viewer) {
 
 		ctx := &Context{
 			Request:  req,
-			Response: rw,
+			Response: NewResponseWriter(rw),
 			Routing:  *r,
 			app:      app,
 		}
@@ -378,7 +378,7 @@ func (app *App) createHandler(pattern string, hf HandleFunc, opts []RoutingOptio
 
 		ctx := &Context{
 			Request:  req,
-			Response: rw,
+			Response: NewResponseWriter(rw),
 			Routing:  *r,
 			app:      app,
 		}

--- a/compressor_deflate.go
+++ b/compressor_deflate.go
@@ -23,7 +23,9 @@ func (c *DeflateCompressor) New(rw http.ResponseWriter) ResponseWriter {
 	w, _ := flate.NewWriter(rw, flate.DefaultCompression) //nolint: errcheck because flate.DefaultCompression is a valid compression level
 
 	return &deflateResponseWriter{
-		w:              w,
-		ResponseWriter: rw,
+		w: w,
+		stdResponseWriter: &stdResponseWriter{
+			ResponseWriter: rw,
+		},
 	}
 }

--- a/compressor_gzip.go
+++ b/compressor_gzip.go
@@ -21,8 +21,10 @@ func (c *GzipCompressor) New(rw http.ResponseWriter) ResponseWriter {
 	rw.Header().Set("Content-Encoding", "gzip")
 
 	return &gzipResponseWriter{
-		w:              gzip.NewWriter(rw),
-		ResponseWriter: rw,
+		w: gzip.NewWriter(rw),
+		stdResponseWriter: &stdResponseWriter{
+			ResponseWriter: rw,
+		},
 	}
 
 }

--- a/context.go
+++ b/context.go
@@ -14,8 +14,8 @@ type Context struct {
 	Response http.ResponseWriter
 	Request  *http.Request
 
-	writtenStatus bool
-	values        map[string]any
+	statusCode int
+	values     map[string]any
 }
 
 // WriteStatus sets the HTTP status code for the response.
@@ -23,10 +23,19 @@ type Context struct {
 // The status code will be sent to the client only once the response body is closed.
 // If a status code is not set, the default status code is 200 (OK).
 func (c *Context) WriteStatus(code int) {
-	if !c.writtenStatus {
+	if c.statusCode == 0 {
 		c.Response.WriteHeader(code)
-		c.writtenStatus = true
+		c.statusCode = code
 	}
+}
+
+// StatusCode returns the current HTTP status code for the response.
+// If no status code has been explicitly set, it defaults to 200 (OK).
+func (c *Context) StatusCode() int {
+	if c.statusCode == 0 {
+		return http.StatusOK
+	}
+	return c.statusCode
 }
 
 // WriteHeader sets a response header.

--- a/context.go
+++ b/context.go
@@ -14,8 +14,7 @@ type Context struct {
 	Response ResponseWriter
 	Request  *http.Request
 
-	statusCode int
-	values     map[string]any
+	values map[string]any
 }
 
 // WriteStatus sets the HTTP status code for the response.
@@ -23,19 +22,7 @@ type Context struct {
 // The status code will be sent to the client only once the response body is closed.
 // If a status code is not set, the default status code is 200 (OK).
 func (c *Context) WriteStatus(code int) {
-	if c.statusCode == 0 {
-		c.Response.WriteHeader(code)
-		c.statusCode = code
-	}
-}
-
-// StatusCode returns the current HTTP status code for the response.
-// If no status code has been explicitly set, it defaults to 200 (OK).
-func (c *Context) StatusCode() int {
-	if c.statusCode == 0 {
-		return http.StatusOK
-	}
-	return c.statusCode
+	c.Response.WriteHeader(code)
 }
 
 // WriteHeader sets a response header.

--- a/context.go
+++ b/context.go
@@ -11,7 +11,7 @@ import (
 type Context struct {
 	Routing  Routing
 	app      *App
-	Response http.ResponseWriter
+	Response ResponseWriter
 	Request  *http.Request
 
 	statusCode int

--- a/context_test.go
+++ b/context_test.go
@@ -252,7 +252,7 @@ func TestMixedViewers(t *testing.T) {
 
 func TestDeleteHeader(t *testing.T) {
 	ctx := &Context{
-		Response: httptest.NewRecorder(),
+		Response: NewResponseWriter(httptest.NewRecorder()),
 	}
 
 	ctx.WriteHeader("test", "value")

--- a/ext/cookie/cookie_test.go
+++ b/ext/cookie/cookie_test.go
@@ -18,7 +18,7 @@ func TestCookie(t *testing.T) {
 	t.Run("set", func(t *testing.T) {
 		ctx := &xun.Context{
 			Request:  httptest.NewRequest(http.MethodGet, "/", nil),
-			Response: httptest.NewRecorder(),
+			Response: xun.NewResponseWriter(httptest.NewRecorder()),
 		}
 		c := http.Cookie{Name: "test", Value: "value"}
 
@@ -33,7 +33,7 @@ func TestCookie(t *testing.T) {
 	t.Run("get", func(t *testing.T) {
 		ctx := &xun.Context{
 			Request:  httptest.NewRequest(http.MethodGet, "/", nil),
-			Response: httptest.NewRecorder(),
+			Response: xun.NewResponseWriter(httptest.NewRecorder()),
 		}
 		c := http.Cookie{Name: "test", Value: "dmFsdWU="} // base64 encoded "value"
 		ctx.Request.Header.Set("Cookie", c.String())
@@ -48,7 +48,7 @@ func TestCookie(t *testing.T) {
 func TestDelete(t *testing.T) {
 	ctx := &xun.Context{
 		Request:  httptest.NewRequest(http.MethodGet, "/", nil),
-		Response: httptest.NewRecorder(),
+		Response: xun.NewResponseWriter(httptest.NewRecorder()),
 	}
 	c := http.Cookie{Name: "test", Value: "dmFsdWU="} // base64 encoded "value"
 	Delete(ctx, c)
@@ -62,7 +62,7 @@ func TestSignedCookie(t *testing.T) {
 		cookie := http.Cookie{Name: "test", Value: "value"}
 		ctx := &xun.Context{
 			Request:  httptest.NewRequest(http.MethodGet, "/", nil),
-			Response: httptest.NewRecorder(),
+			Response: xun.NewResponseWriter(httptest.NewRecorder()),
 		}
 
 		ts, err := SetSigned(ctx, cookie, []byte("secret"))
@@ -79,7 +79,7 @@ func TestSignedCookie(t *testing.T) {
 	t.Run("get", func(t *testing.T) {
 		ctx := &xun.Context{
 			Request:  httptest.NewRequest(http.MethodGet, "/", nil),
-			Response: httptest.NewRecorder(),
+			Response: xun.NewResponseWriter(httptest.NewRecorder()),
 		}
 
 		ts := time.Now()
@@ -102,7 +102,7 @@ func TestSignedCookie(t *testing.T) {
 func TestInvalidCookie(t *testing.T) {
 	t.Run("too_long_value", func(t *testing.T) {
 		ctx := &xun.Context{
-			Response: httptest.NewRecorder(),
+			Response: xun.NewResponseWriter(httptest.NewRecorder()),
 		}
 
 		err := Set(ctx, http.Cookie{
@@ -143,7 +143,7 @@ func TestInvalidCookie(t *testing.T) {
 func TestInvalidSigned(t *testing.T) {
 	t.Run("too_long_value", func(t *testing.T) {
 		ctx := &xun.Context{
-			Response: httptest.NewRecorder(),
+			Response: xun.NewResponseWriter(httptest.NewRecorder()),
 		}
 
 		_, err := SetSigned(ctx, http.Cookie{

--- a/response_writer.go
+++ b/response_writer.go
@@ -10,5 +10,6 @@ import (
 type ResponseWriter interface {
 	http.ResponseWriter
 
+	StatusCode() int
 	Close()
 }

--- a/response_writer_deflate.go
+++ b/response_writer_deflate.go
@@ -8,18 +8,33 @@ import (
 // deflateResponseWriter is a custom http.ResponseWriter that wraps the standard
 // ResponseWriter and compresses the response using the deflate algorithm.
 type deflateResponseWriter struct {
-	w *flate.Writer
 	http.ResponseWriter
+	w          *flate.Writer
+	statusCode int
 }
 
 // Write writes the data to the underlying gzip writer.
 // It implements the io.Writer interface.
-func (w *deflateResponseWriter) Write(p []byte) (int, error) {
-	return w.w.Write(p)
+func (rw *deflateResponseWriter) Write(p []byte) (int, error) {
+	return rw.w.Write(p)
 }
 
 // Close closes the underlying writer, flushing any buffered data to the client.
 // It is important to call this method to ensure all data is properly sent.
-func (w *deflateResponseWriter) Close() {
-	w.w.Close()
+func (rw *deflateResponseWriter) Close() {
+	rw.w.Close()
+}
+
+func (rw *deflateResponseWriter) WriteHeader(statusCode int) {
+	if rw.statusCode == 0 {
+		rw.statusCode = statusCode
+		rw.ResponseWriter.WriteHeader(statusCode)
+	}
+}
+
+func (rw *deflateResponseWriter) StatusCode() int {
+	if rw.statusCode == 0 {
+		return http.StatusOK
+	}
+	return rw.statusCode
 }

--- a/response_writer_deflate.go
+++ b/response_writer_deflate.go
@@ -2,15 +2,13 @@ package xun
 
 import (
 	"compress/flate"
-	"net/http"
 )
 
 // deflateResponseWriter is a custom http.ResponseWriter that wraps the standard
 // ResponseWriter and compresses the response using the deflate algorithm.
 type deflateResponseWriter struct {
-	http.ResponseWriter
-	w          *flate.Writer
-	statusCode int
+	*stdResponseWriter
+	w *flate.Writer
 }
 
 // Write writes the data to the underlying gzip writer.
@@ -23,18 +21,4 @@ func (rw *deflateResponseWriter) Write(p []byte) (int, error) {
 // It is important to call this method to ensure all data is properly sent.
 func (rw *deflateResponseWriter) Close() {
 	rw.w.Close()
-}
-
-func (rw *deflateResponseWriter) WriteHeader(statusCode int) {
-	if rw.statusCode == 0 {
-		rw.statusCode = statusCode
-		rw.ResponseWriter.WriteHeader(statusCode)
-	}
-}
-
-func (rw *deflateResponseWriter) StatusCode() int {
-	if rw.statusCode == 0 {
-		return http.StatusOK
-	}
-	return rw.statusCode
 }

--- a/response_writer_gzip.go
+++ b/response_writer_gzip.go
@@ -2,15 +2,13 @@ package xun
 
 import (
 	"compress/gzip"
-	"net/http"
 )
 
 // gzipResponseWriter is a custom http.ResponseWriter that wraps the standard
 // ResponseWriter and compresses the response using gzip.
 type gzipResponseWriter struct {
-	http.ResponseWriter
-	w          *gzip.Writer
-	statusCode int
+	*stdResponseWriter
+	w *gzip.Writer
 }
 
 // Write writes the data to the underlying gzip writer.
@@ -22,18 +20,4 @@ func (rw *gzipResponseWriter) Write(p []byte) (int, error) {
 // Close closes the gzipResponseWriter, ensuring that the underlying writer is also closed.
 func (rw *gzipResponseWriter) Close() {
 	rw.w.Close()
-}
-
-func (rw *gzipResponseWriter) WriteHeader(statusCode int) {
-	if rw.statusCode == 0 {
-		rw.statusCode = statusCode
-		rw.ResponseWriter.WriteHeader(statusCode)
-	}
-}
-
-func (rw *gzipResponseWriter) StatusCode() int {
-	if rw.statusCode == 0 {
-		return http.StatusOK
-	}
-	return rw.statusCode
 }

--- a/response_writer_gzip.go
+++ b/response_writer_gzip.go
@@ -8,17 +8,32 @@ import (
 // gzipResponseWriter is a custom http.ResponseWriter that wraps the standard
 // ResponseWriter and compresses the response using gzip.
 type gzipResponseWriter struct {
-	w *gzip.Writer
 	http.ResponseWriter
+	w          *gzip.Writer
+	statusCode int
 }
 
 // Write writes the data to the underlying gzip writer.
 // It implements the io.Writer interface.
-func (w *gzipResponseWriter) Write(p []byte) (int, error) {
-	return w.w.Write(p)
+func (rw *gzipResponseWriter) Write(p []byte) (int, error) {
+	return rw.w.Write(p)
 }
 
 // Close closes the gzipResponseWriter, ensuring that the underlying writer is also closed.
-func (w *gzipResponseWriter) Close() {
-	w.w.Close()
+func (rw *gzipResponseWriter) Close() {
+	rw.w.Close()
+}
+
+func (rw *gzipResponseWriter) WriteHeader(statusCode int) {
+	if rw.statusCode == 0 {
+		rw.statusCode = statusCode
+		rw.ResponseWriter.WriteHeader(statusCode)
+	}
+}
+
+func (rw *gzipResponseWriter) StatusCode() int {
+	if rw.statusCode == 0 {
+		return http.StatusOK
+	}
+	return rw.statusCode
 }

--- a/response_writer_std.go
+++ b/response_writer_std.go
@@ -5,9 +5,28 @@ import "net/http"
 // stdResponseWriter is a wrapper around http.ResponseWriter to implement the ResponseWriter interface.
 type stdResponseWriter struct {
 	http.ResponseWriter
+	statusCode int
 }
 
 // Close implements the ResponseWriter interface Close method.
 // It is a no-op for the standard response writer.
 func (*stdResponseWriter) Close() {
+}
+
+func (rw *stdResponseWriter) WriteHeader(statusCode int) {
+	if rw.statusCode == 0 {
+		rw.statusCode = statusCode
+		rw.ResponseWriter.WriteHeader(statusCode)
+	}
+}
+
+func (rw *stdResponseWriter) StatusCode() int {
+	if rw.statusCode == 0 {
+		return http.StatusOK
+	}
+	return rw.statusCode
+}
+
+func NewResponseWriter(rw http.ResponseWriter) ResponseWriter {
+	return &stdResponseWriter{ResponseWriter: rw}
 }

--- a/response_writer_std_test.go
+++ b/response_writer_std_test.go
@@ -1,0 +1,22 @@
+package xun
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriterStatus(t *testing.T) {
+	rw := NewResponseWriter(httptest.NewRecorder())
+
+	require.Equal(t, http.StatusOK, rw.StatusCode())
+
+	rw.WriteHeader(http.StatusNotFound)
+	require.Equal(t, http.StatusNotFound, rw.StatusCode())
+
+	rw.WriteHeader(http.StatusInternalServerError)
+	require.Equal(t, http.StatusNotFound, rw.StatusCode())
+
+}

--- a/viewer_file.go
+++ b/viewer_file.go
@@ -74,8 +74,6 @@ func (v *FileViewer) Render(w http.ResponseWriter, r *http.Request, data any) er
 	if !v.isEmbed {
 		return v.serveContent(w, r)
 	}
-
-	w.Header().Set("ETag", v.etag)
 	if match := r.Header.Get("If-None-Match"); match != "" {
 		for _, it := range strings.Split(match, ",") {
 			if strings.TrimSpace(it) == v.etag {
@@ -83,9 +81,9 @@ func (v *FileViewer) Render(w http.ResponseWriter, r *http.Request, data any) er
 				return nil
 			}
 		}
-
 	}
 
+	w.Header().Set("ETag", v.etag)
 	return v.serveContent(w, r)
 }
 


### PR DESCRIPTION
### Changed
- exposed `StatusCode` in `context`

### Fixed
-

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

New Features:
- Added a StatusCode() method to the Context struct, allowing access to the current HTTP status code.