### PR TITLE
!feat(form): Moved out Binder/Validator to reduce 3rd dependencies in the core class library

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,7 +790,7 @@ admin := app.Group("/admin")
 
 	app.Post("/login", func(c *xun.Context) error {
 
-		it, err := xun.BindForm[Login](c.Request)
+		it, err := form.BindForm[Login](c.Request)
 
 		if err != nil {
 			c.WriteStatus(http.StatusBadRequest)

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ type Login struct {
 #### BindQuery
 ```go
 	app.Get("/login", func(c *Context) error {
-		it, err := xun.BindQuery[Login](c.Request)
+		it, err := form.BindQuery[Login](c.Request)
 		if err != nil {
 			c.WriteStatus(http.StatusBadRequest)
 			return ErrCancelled
@@ -432,7 +432,7 @@ type Login struct {
 #### BindForm
 ```go
 app.Post("/login", func(c *Context) error {
-		it, err := xun.BindForm[Login](c.Request)
+		it, err := form.BindForm[Login](c.Request)
 		if err != nil {
 			c.WriteStatus(http.StatusBadRequest)
 			return ErrCancelled
@@ -449,7 +449,7 @@ app.Post("/login", func(c *Context) error {
 #### BindJson
 ```go
 app.Post("/login", func(c *Context) error {
-		it, err := xun.BindJson[Login](c.Request)
+		it, err := form.BindJson[Login](c.Request)
 		if err != nil {
 			c.WriteStatus(http.StatusBadRequest)
 			return ErrCancelled

--- a/context.go
+++ b/context.go
@@ -3,6 +3,12 @@ package xun
 import (
 	"net/http"
 	"strings"
+
+	jsoniter "github.com/json-iterator/go"
+)
+
+var (
+	json = jsoniter.Config{UseNumber: false}.Froze()
 )
 
 // Context is the primary structure for handling HTTP requests.

--- a/ext/form/binder.go
+++ b/ext/form/binder.go
@@ -1,4 +1,4 @@
-package xun
+package form
 
 import (
 	"net/http"

--- a/ext/form/binder.go
+++ b/ext/form/binder.go
@@ -20,10 +20,8 @@ func BindQuery[T any](req *http.Request) (*TEntity[T], error) {
 
 	data := new(T)
 
-	err := formDecoder.Decode(data, req.URL.Query())
-	if err != nil {
-		return nil, err
-	}
+	// new(T) always is a pointer
+	formDecoder.Decode(data, req.URL.Query()) // nolint: errcheck
 
 	return &TEntity[T]{
 		Data:   *data,
@@ -45,11 +43,8 @@ func BindForm[T any](req *http.Request) (*TEntity[T], error) {
 		return nil, err
 	}
 
-	// r.PostForm is a map of our POST form values
-	err = formDecoder.Decode(data, req.PostForm)
-	if err != nil {
-		return nil, err
-	}
+	// new(T) always is a pointer
+	formDecoder.Decode(data, req.PostForm) // nolint: errcheck
 
 	return &TEntity[T]{
 		Data:   *data,

--- a/ext/form/binder_test.go
+++ b/ext/form/binder_test.go
@@ -188,3 +188,17 @@ func TestBinder(t *testing.T) {
 	}
 
 }
+
+func TestInvalid(t *testing.T) {
+
+	t.Run("invalid_form", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Body = nil
+		_, err := BindForm[int](req)
+		require.NotNil(t, err)
+	})
+	t.Run("invalid_json", func(t *testing.T) {
+		_, err := BindJson[int](httptest.NewRequest(http.MethodGet, "/", strings.NewReader(`"`)))
+		require.NotNil(t, err)
+	})
+}

--- a/ext/form/binder_test.go
+++ b/ext/form/binder_test.go
@@ -1,7 +1,8 @@
-package xun
+package form
 
 import (
 	"bytes"
+	"crypto/tls"
 
 	"net/http"
 	"net/http/httptest"
@@ -13,14 +14,21 @@ import (
 	ut "github.com/go-playground/universal-translator"
 	trans "github.com/go-playground/validator/v10/translations/zh"
 	"github.com/stretchr/testify/require"
+	"github.com/yaitoo/xun"
 )
 
 func TestBinder(t *testing.T) {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // skipcq: GSC-G402, GO-S1020
+	client := http.Client{
+		Transport: tr,
+	}
+
 	mux := http.NewServeMux()
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	app := New(WithMux(mux))
+	app := xun.New(xun.WithMux(mux))
 
 	type Login struct {
 		Email  string `form:"email" json:"email" validate:"required,email"`
@@ -29,11 +37,11 @@ func TestBinder(t *testing.T) {
 
 	AddValidator(ut.New(zh.New()).GetFallback(), trans.RegisterDefaultTranslations)
 
-	app.Get("/login", func(c *Context) error {
+	app.Get("/login", func(c *xun.Context) error {
 		it, err := BindQuery[Login](c.Request)
 		if err != nil {
 			c.WriteStatus(http.StatusBadRequest)
-			return ErrCancelled
+			return xun.ErrCancelled
 		}
 
 		if it.Validate(c.AcceptLanguage()...) && it.Data.Email == "xun@yaitoo.cn" && it.Data.Passwd == "123" {
@@ -45,11 +53,11 @@ func TestBinder(t *testing.T) {
 		return c.View(it)
 	})
 
-	app.Post("/login", func(c *Context) error {
+	app.Post("/login", func(c *xun.Context) error {
 		it, err := BindForm[Login](c.Request)
 		if err != nil {
 			c.WriteStatus(http.StatusBadRequest)
-			return ErrCancelled
+			return xun.ErrCancelled
 		}
 
 		if it.Validate(c.AcceptLanguage()...) && it.Data.Email == "xun@yaitoo.cn" && it.Data.Passwd == "123" {
@@ -61,11 +69,11 @@ func TestBinder(t *testing.T) {
 		return c.View(it)
 	})
 
-	app.Put("/login", func(c *Context) error {
+	app.Put("/login", func(c *xun.Context) error {
 		it, err := BindJson[Login](c.Request)
 		if err != nil {
 			c.WriteStatus(http.StatusBadRequest)
-			return ErrCancelled
+			return xun.ErrCancelled
 		}
 
 		if it.Validate(c.AcceptLanguage()...) && it.Data.Email == "xun@yaitoo.cn" && it.Data.Passwd == "123" {

--- a/ext/form/validate.go
+++ b/ext/form/validate.go
@@ -1,4 +1,4 @@
-package xun
+package form
 
 import (
 	"github.com/go-playground/locales/en"


### PR DESCRIPTION
### Changed
- !feat(form): Moved out Binder/Validator to reduce 3rd dependencies in the core class library

### Fixed
-

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Move the Binder and Validator components to a separate package to reduce third-party dependencies in the core library.

New Features:
- Introduce a new `form` package that contains the Binder and Validator components.

Enhancements:
- Reduce third-party dependencies in the core class library by moving the Binder and Validator out of it.