### PR TITLE
fix(hsts): added IgnoreRules on Redirect

### DIFF
--- a/ext/hsts/option.go
+++ b/ext/hsts/option.go
@@ -1,6 +1,10 @@
 package hsts
 
-import "time"
+import (
+	"net/http"
+	"strings"
+	"time"
+)
 
 // Config represents the configuration options for HSTS (HTTP Strict Transport Security).
 // It includes various settings such as MaxAge, IncludeSubDomains, and Preload.
@@ -37,5 +41,18 @@ func WithIncludeSubDomains() Option {
 func WithPreload() Option {
 	return func(c *Config) {
 		c.Preload = true
+	}
+}
+
+type IgnoreRule func(*http.Request) bool
+
+func Ignore(paths ...string) IgnoreRule {
+	return func(r *http.Request) bool {
+		for _, path := range paths {
+			if strings.EqualFold(r.URL.Path, path) {
+				return true
+			}
+		}
+		return false
 	}
 }


### PR DESCRIPTION
### Changed
-

### Fixed
-

### Added
-  added `IgnoreRule` on `Redirect`

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Add an option to ignore specific paths when redirecting HTTP requests to HTTPS.

New Features:
- Added `IgnoreRule` to the `Redirect` middleware to allow ignoring specific paths when redirecting to HTTPS.

Tests:
- Added tests for the new ignore functionality in `Redirect` middleware.