### PR TITLE
fix(hsts): added StartsWith rule

### DIFF
--- a/ext/hsts/hsts_test.go
+++ b/ext/hsts/hsts_test.go
@@ -149,7 +149,7 @@ func TestRedirect(t *testing.T) {
 		srv := httptest.NewServer(mux)
 		defer srv.Close()
 		app := xun.New(xun.WithMux(mux))
-		app.Use(Redirect(Ignore("/status")))
+		app.Use(Redirect(Match("/status"), StartsWith("/images")))
 
 		u, err := url.Parse(srv.URL)
 		require.NoError(t, err)
@@ -169,6 +169,14 @@ func TestRedirect(t *testing.T) {
 		require.Equal(t, "", resp.Header.Get("Strict-Transport-Security"))
 
 		req, err = http.NewRequest(http.MethodGet, srv.URL+"/status", nil)
+		require.NoError(t, err)
+		resp, err = c.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, "", resp.Header.Get("Location"))
+		require.Equal(t, "", resp.Header.Get("Strict-Transport-Security"))
+
+		req, err = http.NewRequest(http.MethodGet, srv.URL+"/images/xxx", nil)
 		require.NoError(t, err)
 		resp, err = c.Do(req)
 		require.NoError(t, err)

--- a/ext/hsts/option.go
+++ b/ext/hsts/option.go
@@ -65,14 +65,16 @@ func Match(paths ...string) IgnoreRule {
 
 // StartsWith creates an IgnoreRule that checks if the request path starts with any of the specified prefixes.
 //
-// paths MUST be lower case.
-//
-// This function returns an IgnoreRule that converts the request path to lowercase and checks for a prefix match.
-// It is useful for ignoring requests with paths that match specified patterns.
+// The provided paths are automatically converted to lower-case for consistent matching.
 func StartsWith(paths ...string) IgnoreRule {
+	// Convert provided paths to lower-case once for consistent matching.
+	lowerPaths := make([]string, len(paths))
+	for i, p := range paths {
+		lowerPaths[i] = strings.ToLower(p)
+	}
 	return func(r *http.Request) bool {
 		l := strings.ToLower(r.URL.Path)
-		for _, path := range paths {
+		for _, path := range lowerPaths {
 			if strings.HasPrefix(l, path) {
 				return true
 			}

--- a/ext/hsts/option.go
+++ b/ext/hsts/option.go
@@ -44,12 +44,36 @@ func WithPreload() Option {
 	}
 }
 
+// IgnoreRule is a function that takes a pointer to an http.Request
+// and returns a boolean indicating whether the request should be
+// ignored by the HSTS middleware.
 type IgnoreRule func(*http.Request) bool
 
-func Ignore(paths ...string) IgnoreRule {
+// Match creates an IgnoreRule that matches the given paths to ignore requests.
+//
+// The paths are matched case-insensitively, so "/Doc" and "/doc" would be equivalent.
+func Match(paths ...string) IgnoreRule {
 	return func(r *http.Request) bool {
 		for _, path := range paths {
 			if strings.EqualFold(r.URL.Path, path) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// StartsWith creates an IgnoreRule that checks if the request path starts with any of the specified prefixes.
+//
+// paths MUST be lower case.
+//
+// This function returns an IgnoreRule that converts the request path to lowercase and checks for a prefix match.
+// It is useful for ignoring requests with paths that match specified patterns.
+func StartsWith(paths ...string) IgnoreRule {
+	return func(r *http.Request) bool {
+		l := strings.ToLower(r.URL.Path)
+		for _, path := range paths {
+			if strings.HasPrefix(l, path) {
 				return true
 			}
 		}


### PR DESCRIPTION
### Changed
-

### Fixed
-

### Added
- added `StartsWith` rule in `Redirect`

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Add a new `StartsWith` rule to the `Redirect` middleware, allowing requests with paths that start with specific prefixes to be ignored by HSTS.

New Features:
- Added the `StartsWith` rule to the `Redirect` middleware in the `hsts` extension.

Tests:
- Added tests for the new `StartsWith` rule.