### PR TITLE
fix(ext): added support to X-Forwarded-Proto in https checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,7 +787,7 @@ app.Use(acl.New(acl.WithConfig("./acl.ini")))
 ```
 
 ### Deploy your application
-Leveraging Go's built-in `//go:embed` directive and the standard library's `fs.FS` interface, we can compile all static assets and configuration files into a single self-contained binary. This dependency-free approach enables seamless deployment to any server environment while maintaining full portability and simplified operational management.
+Leveraging Go's built-in `//go:embed` directive and the standard library's `fs.FS` interface, we can compile all static assets and configuration files into a single self-contained binary. This dependency-free approach enables seamless deployment to any server environment.
 
 ```go
 

--- a/ext/hsts/hsts.go
+++ b/ext/hsts/hsts.go
@@ -43,8 +43,7 @@ func WriteHeader(opts ...Option) xun.Middleware {
 	return func(next xun.HandleFunc) xun.HandleFunc {
 		return func(c *xun.Context) error {
 			r := c.Request
-
-			if r.TLS != nil && (r.Method == "GET" || r.Method == "HEAD") {
+			if (r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https") && (r.Method == "GET" || r.Method == "HEAD") {
 				v := "max-age=" + strconv.FormatInt(cfg.MaxAge, 10)
 				if cfg.IncludeSubDomains {
 					v += "; includeSubDomains"

--- a/ext/reqlog/format.go
+++ b/ext/reqlog/format.go
@@ -3,6 +3,7 @@ package reqlog
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"strings"
 	"time"
 
@@ -38,8 +39,16 @@ func VCombined(c *xun.Context, options *Options, starts time.Time) {
 	remoteAddr, _, _ := net.SplitHostPort(c.Request.RemoteAddr)
 	host := c.Request.Host
 
+	if host == "" {
+		host = c.Request.URL.Host
+	}
+
 	if !strings.Contains(host, ":") {
-		host += ":"
+		if IsHTTPs(c.Request) {
+			host += ":" + "443"
+		} else {
+			host += ":" + "80"
+		}
 	}
 
 	//VCombined: host、remote、visitor、user、datetime、request line、status、body_bytes_sent、referer、user-agent
@@ -72,6 +81,10 @@ func Common(c *xun.Context, options *Options, starts time.Time) {
 		c.Response.StatusCode(),
 		c.Response.BodyBytesSent(),
 	)
+}
+
+func IsHTTPs(r *http.Request) bool {
+	return r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
 }
 
 func Escape(s string) string {

--- a/ext/reqlog/log_test.go
+++ b/ext/reqlog/log_test.go
@@ -87,7 +87,7 @@ func TestLogging(t *testing.T) {
 
 		l := buf.String()
 
-		require.True(t, strings.HasPrefix(l, `abc.com: 192.0.2.1 "combined-vid" "combined-uid" [`))
+		require.True(t, strings.HasPrefix(l, `abc.com:80 192.0.2.1 "combined-vid" "combined-uid" [`))
 		require.True(t, strings.HasSuffix(l, "] \"GET / HTTP/1.1\" 200 0 \"combined-referer\" \"combined-agent\"\n"))
 	})
 

--- a/ext/reqlog/log_test.go
+++ b/ext/reqlog/log_test.go
@@ -91,7 +91,7 @@ func TestLogging(t *testing.T) {
 		require.True(t, strings.HasSuffix(l, "] \"GET / HTTP/1.1\" 200 0 \"combined-referer\" \"combined-agent\"\n"))
 	})
 
-	t.Run("vcombined_with_port", func(t *testing.T) {
+	t.Run("vcombined_custom_port", func(t *testing.T) {
 		buf := bytes.Buffer{}
 
 		logger := log.New(&buf, "", 0)
@@ -120,6 +120,71 @@ func TestLogging(t *testing.T) {
 		l := buf.String()
 
 		require.True(t, strings.HasPrefix(l, `abc.com:8080 192.0.2.1 "combined-vid" "combined-uid" [`))
+		require.True(t, strings.HasSuffix(l, "] \"GET / HTTP/1.1\" 200 0 \"combined-referer\" \"combined-agent\"\n"))
+	})
+
+	t.Run("vcombined_https_port", func(t *testing.T) {
+		buf := bytes.Buffer{}
+
+		logger := log.New(&buf, "", 0)
+		m := New(WithLogger(logger),
+			WithUser(getUser),
+			WithVisitor(getVisitor),
+			WithFormat(VCombined))
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Host = "abc.com"
+		req.Header.Set("Host", "abc.com")
+		req.Header.Set("X-Forwarded-Proto", "https")
+		req.Header.Set("X-Visitor-Id", "combined-vid")
+		req.Header.Set("X-User-Id", "combined-uid")
+		req.Header.Set("User-Agent", "combined-agent")
+		req.Header.Set("Referer", "combined-referer")
+
+		ctx := &xun.Context{
+			Request:  req,
+			Response: xun.NewResponseWriter(httptest.NewRecorder()),
+		}
+
+		err := m(nop)(ctx)
+
+		require.NoError(t, err)
+
+		l := buf.String()
+
+		require.True(t, strings.HasPrefix(l, `abc.com:443 192.0.2.1 "combined-vid" "combined-uid" [`))
+		require.True(t, strings.HasSuffix(l, "] \"GET / HTTP/1.1\" 200 0 \"combined-referer\" \"combined-agent\"\n"))
+	})
+
+	t.Run("vcombined_empty_host", func(t *testing.T) {
+		buf := bytes.Buffer{}
+
+		logger := log.New(&buf, "", 0)
+		m := New(WithLogger(logger),
+			WithUser(getUser),
+			WithVisitor(getVisitor),
+			WithFormat(VCombined))
+
+		req := httptest.NewRequest(http.MethodGet, "http://123.com/", nil)
+		req.Host = ""
+		req.Header.Set("X-Forwarded-Proto", "https")
+		req.Header.Set("X-Visitor-Id", "combined-vid")
+		req.Header.Set("X-User-Id", "combined-uid")
+		req.Header.Set("User-Agent", "combined-agent")
+		req.Header.Set("Referer", "combined-referer")
+
+		ctx := &xun.Context{
+			Request:  req,
+			Response: xun.NewResponseWriter(httptest.NewRecorder()),
+		}
+
+		err := m(nop)(ctx)
+
+		require.NoError(t, err)
+
+		l := buf.String()
+
+		require.True(t, strings.HasPrefix(l, `123.com:443 192.0.2.1 "combined-vid" "combined-uid" [`))
 		require.True(t, strings.HasSuffix(l, "] \"GET / HTTP/1.1\" 200 0 \"combined-referer\" \"combined-agent\"\n"))
 	})
 


### PR DESCRIPTION
### Changed
-

### Fixed
- added support to `X-Forwarded-Proto` in https checking

### Added
- added `Deploy` section on README.md

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Add support for `X-Forward-Proto` header and document the deployment process. Update the HTTPS checking logic to handle the `X-Forward-Proto` header, enabling proper identification of HTTPS requests when the application is deployed behind a proxy. Include a new section in the README explaining how to deploy the application using embedded static assets and configuration files for a simplified and portable deployment process.

Bug Fixes:
- Added support for the `X-Forward-Proto` header in HTTPS checking logic to correctly identify HTTPS requests behind a proxy.

Documentation:
- Added a "Deploy" section to the README.md file, explaining how to deploy the application using embedded resources and the `//go:embed` directive for self-contained binaries.