### PR TITLE
!fix(viewer): pass `*Context` into viewer.Render

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ We use github to host code, to track issues and feature requests, as well as acc
 5. Make sure your code lints: `make lint`.
 6. Issue that pull request!
 
-### Any contributions you make will be under the MIT Software License
+### Any contributions you make will be under the Apache-2.0 license 
 In short, when you submit code changes, your submissions are understood to be under the same [Apache-2.0 license](LICENSE) that covers the project. Feel free to contact the maintainers if that's a concern.
 
 ### Report bugs using Github's [Issues](https://github.com/yaitoo/xun/issues)

--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@ Xun is an HTTP web framework built on Go's built-in html/template and net/http p
 Xun [ʃʊn] (pronounced 'shoon'), derived from the Chinese character 迅, signifies being lightweight and fast.
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+|
 [![Tests](https://github.com/yaitoo/xun/actions/workflows/tests.yml/badge.svg)](https://github.com/yaitoo/xun/actions/workflows/tests.yml)
-[![Go Reference](https://pkg.go.dev/badge/github.com/yaitoo/xun.svg)](https://pkg.go.dev/github.com/yaitoo/xun)
 [![Codecov](https://codecov.io/gh/yaitoo/xun/branch/main/graph/badge.svg)](https://codecov.io/gh/yaitoo/xun)
-[![GitHub Release](https://img.shields.io/github/v/release/yaitoo/xun?logo=go)](https://github.com/yaitoo/xun/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/yaitoo/xun)](https://goreportcard.com/report/github.com/yaitoo/xun)
+|
+[![Go Reference](https://pkg.go.dev/badge/github.com/yaitoo/xun.svg)](https://pkg.go.dev/github.com/yaitoo/xun)
+[![GitHub Release](https://img.shields.io/github/v/release/yaitoo/xun?logo=go)](https://github.com/yaitoo/xun/releases)
+|
 [![Issues welcome](https://img.shields.io/badge/Issues-welcome-blue.svg)](https://github.com/yaitoo/xun/issues/new)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-blue.svg)](https://github.com/yaitoo/xun/compare)
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@ Xun [ʃʊn] (pronounced 'shoon'), derived from the Chinese character 迅, signif
 
 [![Tests](https://github.com/yaitoo/xun/actions/workflows/tests.yml/badge.svg)](https://github.com/yaitoo/xun/actions/workflows/tests.yml)
 [![Codecov](https://codecov.io/gh/yaitoo/xun/branch/main/graph/badge.svg)](https://codecov.io/gh/yaitoo/xun)
-[![Go Report Card](https://goreportcard.com/badge/github.com/yaitoo/xun)](https://goreportcard.com/report/github.com/yaitoo/xun)|
-
+[![Go Report Card](https://goreportcard.com/badge/github.com/yaitoo/xun)](https://goreportcard.com/report/github.com/yaitoo/xun)
 [![Go Reference](https://pkg.go.dev/badge/github.com/yaitoo/xun.svg)](https://pkg.go.dev/github.com/yaitoo/xun)
-[![GitHub Release](https://img.shields.io/github/v/release/yaitoo/xun)](https://github.com/yaitoo/xun/releases)|
-
+[![GitHub Release](https://img.shields.io/github/v/release/yaitoo/xun)](https://github.com/yaitoo/xun/releases)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-blue.svg)](https://github.com/yaitoo/xun/compare)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Xun [ʃʊn] (pronounced 'shoon'), derived from the Chinese character 迅, signif
 [![Tests](https://github.com/yaitoo/xun/actions/workflows/tests.yml/badge.svg)](https://github.com/yaitoo/xun/actions/workflows/tests.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/yaitoo/xun.svg)](https://pkg.go.dev/github.com/yaitoo/xun)
 [![Codecov](https://codecov.io/gh/yaitoo/xun/branch/main/graph/badge.svg)](https://codecov.io/gh/yaitoo/xun)
-[![GitHub Release](https://img.shields.io/github/v/release/yaitoo/xun)](https://github.com/yaitoo/xun/blob/main/CHANGELOG.md)
+[![GitHub Release](https://img.shields.io/github/v/release/yaitoo/xun?logo=go&color=green)](https://github.com/yaitoo/xun/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/yaitoo/xun)](https://goreportcard.com/report/github.com/yaitoo/xun)
 [![Issues welcome](https://img.shields.io/badge/Issues-welcome-brightgreen.svg)](https://github.com/yaitoo/xun/issues/new)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/yaitoo/xun/compare)

--- a/README.md
+++ b/README.md
@@ -924,8 +924,8 @@ Add your compiled CSS file to the `assets.html` and start using Tailwind’s uti
 {{ define "content" }}
     <div id="app" class="text-3xl font-bold underline" hx-boost="true">
 
-			{{ if .Context.Values.session }}
-				Hello {{ .Context.Values.session }}, go <a href="/admin">Admin</>
+			{{ if .TempData.Session }}
+				Hello {{ .TempData.Session }}, go <a href="/admin">Admin</>
 			{{ else }}
         Hello guest, please <a href="/login">Login</a>	
 			{{ end }}    
@@ -1015,9 +1015,9 @@ create an `admin` group router, and apply a middleware to check if it's logged. 
 				return xun.ErrCancelled
 			}
 
-			// set session in Context.Values, 
-			// and get it by `.Context.Values.session on text/html template files
-			c.Set("session", s.Value)
+			// set session in Context.TempData, 
+			// and get it by `.TempData.Session on text/html template files
+			c.Set("Session", s.Value)
 			return next(c)
 		}
 	})

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Xun is an HTTP web framework built on Go's built-in html/template and net/http p
 
 Xun [ʃʊn] (pronounced 'shoon'), derived from the Chinese character 迅, signifies being lightweight and fast.
 
-[![License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg)](LICENSE)
 [![Tests](https://github.com/yaitoo/xun/actions/workflows/tests.yml/badge.svg)](https://github.com/yaitoo/xun/actions/workflows/tests.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/yaitoo/xun.svg)](https://pkg.go.dev/github.com/yaitoo/xun)
 [![Codecov](https://codecov.io/gh/yaitoo/xun/branch/main/graph/badge.svg)](https://codecov.io/gh/yaitoo/xun)
-[![GitHub Release](https://img.shields.io/github/v/release/yaitoo/xun?logo=go&color=green)](https://github.com/yaitoo/xun/releases)
+[![GitHub Release](https://img.shields.io/github/v/release/yaitoo/xun?logo=go&color=brightgreen)](https://github.com/yaitoo/xun/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/yaitoo/xun)](https://goreportcard.com/report/github.com/yaitoo/xun)
 [![Issues welcome](https://img.shields.io/badge/Issues-welcome-brightgreen.svg)](https://github.com/yaitoo/xun/issues/new)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/yaitoo/xun/compare)

--- a/README.md
+++ b/README.md
@@ -923,9 +923,12 @@ Add your compiled CSS file to the `assets.html` and start using Tailwind’s uti
 <!--layout:home-->
 {{ define "content" }}
     <div id="app" class="text-3xl font-bold underline" hx-boost="true">
-        <span>hello {{.Data.Name}}</span>
 
-        <a href="/admin/">admin</a>
+			{{ if .Context.Values.session }}
+				Hello {{ .Context.Values.session }}, go <a href="/admin">Admin</>
+			{{ else }}
+        Hello guest, please <a href="/login">Login</a>	
+			{{ end }}    
     </div>
 
 {{ end }}
@@ -974,11 +977,7 @@ Add your compiled CSS file to the `assets.html` and start using Tailwind’s uti
 <!--layout:home-->
 {{ define "content" }}
     <div id="app" class="text-3xl font-bold underline">
-			{{ if .Context.Values.session }}
 				Hello admin: {{ .Data.Name }}
-			{{ else }}
-        Hello guest
-			{{ end }}
 			</div>
 {{ end }}
 ```

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Page Router only serve static content from html files. We have to define router 
 ```html
 <!--layout:home-->
 {{ define "content" }}
-    <div id="app">hello {{.Name}}</div>
+    <div id="app">hello {{.Data.Name}}</div>
 {{ end }}
 ```
 
@@ -266,7 +266,7 @@ For examples, below patterns will be generated automatically, and registered in 
 ```html
 <!--layout:home-->
 {{ define "content" }}
-    <div id="app">hello {{.Name}}</div>
+    <div id="app">hello {{.Data.Name}}</div>
 {{ end }}
 ```
 
@@ -924,7 +924,7 @@ Add your compiled CSS file to the `assets.html` and start using Tailwind’s uti
 <!--layout:home-->
 {{ define "content" }}
     <div id="app" class="text-3xl font-bold underline" hx-boost="true">
-        <span>hello {{.Name}}</span>
+        <span>hello {{.Data.Name}}</span>
 
         <a href="/admin/">admin</a>
     </div>
@@ -974,7 +974,13 @@ Add your compiled CSS file to the `assets.html` and start using Tailwind’s uti
 ```html
 <!--layout:home-->
 {{ define "content" }}
-    <div id="app" class="text-3xl font-bold underline">Hello admin: {{.Name}}</div>
+    <div id="app" class="text-3xl font-bold underline">
+			{{ if .Context.Values.session }}
+				Hello admin: {{ .Data.Name }}
+			{{ else }}
+        Hello guest
+			{{ end }}
+			</div>
 {{ end }}
 ```
 
@@ -1011,6 +1017,8 @@ create an `admin` group router, and apply a middleware to check if it's logged. 
 				return xun.ErrCancelled
 			}
 
+			// set session in Context.Values, 
+			// and get it by `.Context.Values.session on text/html template files
 			c.Set("session", s.Value)
 			return next(c)
 		}

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ Xun is an HTTP web framework built on Go's built-in html/template and net/http p
 
 Xun [ʃʊn] (pronounced 'shoon'), derived from the Chinese character 迅, signifies being lightweight and fast.
 
-[![License](https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Tests](https://github.com/yaitoo/xun/actions/workflows/tests.yml/badge.svg)](https://github.com/yaitoo/xun/actions/workflows/tests.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/yaitoo/xun.svg)](https://pkg.go.dev/github.com/yaitoo/xun)
 [![Codecov](https://codecov.io/gh/yaitoo/xun/branch/main/graph/badge.svg)](https://codecov.io/gh/yaitoo/xun)
-[![GitHub Release](https://img.shields.io/github/v/release/yaitoo/xun?logo=go&color=brightgreen)](https://github.com/yaitoo/xun/releases)
+[![GitHub Release](https://img.shields.io/github/v/release/yaitoo/xun?logo=go)](https://github.com/yaitoo/xun/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/yaitoo/xun)](https://goreportcard.com/report/github.com/yaitoo/xun)
-[![Issues welcome](https://img.shields.io/badge/Issues-welcome-brightgreen.svg)](https://github.com/yaitoo/xun/issues/new)
-[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/yaitoo/xun/compare)
+[![Issues welcome](https://img.shields.io/badge/Issues-welcome-blue.svg)](https://github.com/yaitoo/xun/issues/new)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-blue.svg)](https://github.com/yaitoo/xun/compare)
 
 ## Features
 - Works with Go's built-in `net/http.ServeMux` router that was introduced in 1.22. [Routing Enhancements for Go 1.22](https://go.dev/blog/routing-enhancements).

--- a/README.md
+++ b/README.md
@@ -3,16 +3,14 @@ Xun is an HTTP web framework built on Go's built-in html/template and net/http p
 
 Xun [ʃʊn] (pronounced 'shoon'), derived from the Chinese character 迅, signifies being lightweight and fast.
 
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-|
 [![Tests](https://github.com/yaitoo/xun/actions/workflows/tests.yml/badge.svg)](https://github.com/yaitoo/xun/actions/workflows/tests.yml)
 [![Codecov](https://codecov.io/gh/yaitoo/xun/branch/main/graph/badge.svg)](https://codecov.io/gh/yaitoo/xun)
-[![Go Report Card](https://goreportcard.com/badge/github.com/yaitoo/xun)](https://goreportcard.com/report/github.com/yaitoo/xun)
-|
+[![Go Report Card](https://goreportcard.com/badge/github.com/yaitoo/xun)](https://goreportcard.com/report/github.com/yaitoo/xun)|
+
 [![Go Reference](https://pkg.go.dev/badge/github.com/yaitoo/xun.svg)](https://pkg.go.dev/github.com/yaitoo/xun)
-[![GitHub Release](https://img.shields.io/github/v/release/yaitoo/xun?logo=go)](https://github.com/yaitoo/xun/releases)
-|
-[![Issues welcome](https://img.shields.io/badge/Issues-welcome-blue.svg)](https://github.com/yaitoo/xun/issues/new)
+[![GitHub Release](https://img.shields.io/github/v/release/yaitoo/xun)](https://github.com/yaitoo/xun/releases)|
+
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-blue.svg)](https://github.com/yaitoo/xun/compare)
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Xun [ʃʊn] (pronounced 'shoon'), derived from the Chinese character 迅, signif
 [![Codecov](https://codecov.io/gh/yaitoo/xun/branch/main/graph/badge.svg)](https://codecov.io/gh/yaitoo/xun)
 [![GitHub Release](https://img.shields.io/github/v/release/yaitoo/xun)](https://github.com/yaitoo/xun/blob/main/CHANGELOG.md)
 [![Go Report Card](https://goreportcard.com/badge/github.com/yaitoo/xun)](https://goreportcard.com/report/github.com/yaitoo/xun)
+[![Issues welcome](https://img.shields.io/badge/Issues-welcome-brightgreen.svg)](https://github.com/yaitoo/xun/issues/new)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/yaitoo/xun/compare)
 
 ## Features
 - Works with Go's built-in `net/http.ServeMux` router that was introduced in 1.22. [Routing Enhancements for Go 1.22](https://go.dev/blog/routing-enhancements).

--- a/app.go
+++ b/app.go
@@ -225,6 +225,7 @@ func (app *App) HandleFile(name string, v *FileViewer) {
 			Response: rw,
 			Routing:  *r,
 			App:      app,
+			TempData: make(map[string]any),
 		}
 
 		err := r.Next(ctx)
@@ -283,6 +284,7 @@ func (app *App) HandlePage(pattern string, viewName string, v Viewer) {
 			Response: rw,
 			Routing:  *r,
 			App:      app,
+			TempData: make(map[string]any),
 		}
 
 		err := r.Next(ctx)
@@ -381,6 +383,7 @@ func (app *App) createHandler(pattern string, hf HandleFunc, opts []RoutingOptio
 			Response: rw,
 			Routing:  *r,
 			App:      app,
+			TempData: make(map[string]any),
 		}
 
 		err := r.Next(ctx)

--- a/app.go
+++ b/app.go
@@ -202,7 +202,7 @@ func (app *App) HandleFile(name string, v *FileViewer) {
 	app.viewers[name] = v
 
 	hf := func(c *Context) error {
-		return v.Render(c.Response, c.Request, nil)
+		return v.Render(c, nil)
 	}
 
 	r = &Routing{
@@ -260,7 +260,7 @@ func (app *App) HandlePage(pattern string, viewName string, v Viewer) {
 	app.viewers[viewName] = v
 
 	hf := func(c *Context) error {
-		return v.Render(c.Response, c.Request, nil)
+		return v.Render(c, nil)
 	}
 
 	r = &Routing{

--- a/app_test.go
+++ b/app_test.go
@@ -617,12 +617,12 @@ func TestDataBindOnHtml(t *testing.T) {
 <tbody>
 <tr><th>Name</th><th>ID</th></tr>
 </tbody>
-{{range .}}<tr><td>{{.Name}}</td><td>{{.ID}}</td></tr>{{end}}
+{{range .Data}}<tr><td>{{.Name}}</td><td>{{.ID}}</td></tr>{{end}}
 </tbody>
 </table>
 </body></html>`)},
 		"pages/user/{id}.html": {Data: []byte(`<html><body>
-<div>{{ ToUpper .Name}}: {{.ID}}</div>
+<div>{{ ToUpper .Data.Name}}: {{.Data.ID}}</div>
 </body></html>`)},
 	}
 

--- a/context.go
+++ b/context.go
@@ -20,7 +20,7 @@ type Context struct {
 	Response ResponseWriter
 	Request  *http.Request
 
-	Values map[string]any
+	TempData map[string]any
 }
 
 // WriteStatus sets the HTTP status code for the response.
@@ -183,18 +183,18 @@ func (c *Context) RequestReferer() string {
 // Get retrieves a value from the context's values map by key.
 // If the values map is nil or the key does not exist, it returns nil.
 func (c *Context) Get(key string) any {
-	if c.Values == nil {
+	if c.TempData == nil {
 		return nil
 	}
 
-	return c.Values[key]
+	return c.TempData[key]
 }
 
 // Set assigns a value to the specified key in the context's values map.
 // If the values map is nil, it initializes a new map.
 func (c *Context) Set(key string, value any) {
-	if c.Values == nil {
-		c.Values = make(map[string]any)
+	if c.TempData == nil {
+		c.TempData = make(map[string]any)
 	}
-	c.Values[key] = value
+	c.TempData[key] = value
 }

--- a/context.go
+++ b/context.go
@@ -20,7 +20,7 @@ type Context struct {
 	Response ResponseWriter
 	Request  *http.Request
 
-	values map[string]any
+	Values map[string]any
 }
 
 // WriteStatus sets the HTTP status code for the response.
@@ -83,7 +83,7 @@ func (c *Context) View(data any, options ...string) error {
 		}
 	}
 
-	return v.Render(c.Response, c.Request, data)
+	return v.Render(c, data)
 }
 
 // getViewer get viewer by name
@@ -183,18 +183,18 @@ func (c *Context) RequestReferer() string {
 // Get retrieves a value from the context's values map by key.
 // If the values map is nil or the key does not exist, it returns nil.
 func (c *Context) Get(key string) any {
-	if c.values == nil {
+	if c.Values == nil {
 		return nil
 	}
 
-	return c.values[key]
+	return c.Values[key]
 }
 
 // Set assigns a value to the specified key in the context's values map.
 // If the values map is nil, it initializes a new map.
 func (c *Context) Set(key string, value any) {
-	if c.values == nil {
-		c.values = make(map[string]any)
+	if c.Values == nil {
+		c.Values = make(map[string]any)
 	}
-	c.values[key] = value
+	c.Values[key] = value
 }

--- a/context.go
+++ b/context.go
@@ -11,6 +11,8 @@ var (
 	json = jsoniter.Config{UseNumber: false}.Froze()
 )
 
+type TempData map[string]any
+
 // Context is the primary structure for handling HTTP requests.
 // It encapsulates the request, response, routing information, and application context.
 // It offers various methods to work with request data, manipulate responses, and manage routing.
@@ -20,7 +22,7 @@ type Context struct {
 	Response ResponseWriter
 	Request  *http.Request
 
-	TempData map[string]any
+	TempData TempData
 }
 
 // WriteStatus sets the HTTP status code for the response.
@@ -180,21 +182,12 @@ func (c *Context) RequestReferer() string {
 	return v
 }
 
-// Get retrieves a value from the context's values map by key.
-// If the values map is nil or the key does not exist, it returns nil.
+// Get retrieves a value from the context's TempData by key.
 func (c *Context) Get(key string) any {
-	if c.TempData == nil {
-		return nil
-	}
-
 	return c.TempData[key]
 }
 
-// Set assigns a value to the specified key in the context's values map.
-// If the values map is nil, it initializes a new map.
+// Set assigns a value to the specified key in the context's TempData.
 func (c *Context) Set(key string, value any) {
-	if c.TempData == nil {
-		c.TempData = make(map[string]any)
-	}
 	c.TempData[key] = value
 }

--- a/context_test.go
+++ b/context_test.go
@@ -42,7 +42,7 @@ func TestContextRequestReferer(t *testing.T) {
 	}
 }
 
-func TestContextVars(t *testing.T) {
+func TestTempData(t *testing.T) {
 
 	srv := httptest.NewServer(http.DefaultServeMux)
 	defer srv.Close()

--- a/ext/acl/acl_test.go
+++ b/ext/acl/acl_test.go
@@ -265,7 +265,7 @@ func TestCountries(t *testing.T) {
 		w := httptest.NewRecorder()
 		ctx = createContext(w)
 
-		text, err := template.New("403").Parse("{{ .Host }}-{{ .IP }}-{{.Country}}")
+		text, err := template.New("403").Parse("{{ .Data.Host }}-{{ .Data.IP }}-{{.Data.Country}}")
 		require.NoError(t, err)
 		v := xun.NewTextViewer(xun.NewTextTemplate(text))
 

--- a/group_test.go
+++ b/group_test.go
@@ -14,7 +14,7 @@ import (
 func TestGroup(t *testing.T) {
 
 	fsys := &fstest.MapFS{
-		"pages/admin/index.html": &fstest.MapFile{Data: []byte(`{{.}}`)},
+		"pages/admin/index.html": &fstest.MapFile{Data: []byte(`{{.Data}}`)},
 	}
 
 	mux := http.NewServeMux()

--- a/viewer.go
+++ b/viewer.go
@@ -17,3 +17,9 @@ type Viewer interface {
 	MimeType() *MimeType
 	Render(ctx *Context, data any) error
 }
+
+// ContextData holds the context and associated data for rendering.
+type ContextData struct {
+	Context *Context
+	Data    any
+}

--- a/viewer.go
+++ b/viewer.go
@@ -18,8 +18,8 @@ type Viewer interface {
 	Render(ctx *Context, data any) error
 }
 
-// ContextData holds the context and associated data for rendering.
-type ContextData struct {
-	Context *Context
-	Data    any
+// ViewModel holds the context and associated data for rendering.
+type ViewModel struct {
+	TempData map[string]any
+	Data     any
 }

--- a/viewer.go
+++ b/viewer.go
@@ -1,9 +1,5 @@
 package xun
 
-import (
-	"net/http"
-)
-
 // BufPool is a pool of *bytes.Buffer for reuse to reduce memory alloc.
 //
 // It is used by the Viewer to render the content.
@@ -19,5 +15,5 @@ func init() {
 // an effective viewer.
 type Viewer interface {
 	MimeType() *MimeType
-	Render(w http.ResponseWriter, r *http.Request, data any) error
+	Render(ctx *Context, data any) error
 }

--- a/viewer_file.go
+++ b/viewer_file.go
@@ -70,21 +70,21 @@ func (*FileViewer) MimeType() *MimeType {
 
 // Render serves a file from the file system using the FileViewer.
 // It writes the file to the http.ResponseWriter.
-func (v *FileViewer) Render(w http.ResponseWriter, r *http.Request, data any) error {
+func (v *FileViewer) Render(ctx *Context, data any) error {
 	if !v.isEmbed {
-		return v.serveContent(w, r)
+		return v.serveContent(ctx.Response, ctx.Request)
 	}
-	if match := r.Header.Get("If-None-Match"); match != "" {
+	if match := ctx.Request.Header.Get("If-None-Match"); match != "" {
 		for _, it := range strings.Split(match, ",") {
 			if strings.TrimSpace(it) == v.etag {
-				w.WriteHeader(http.StatusNotModified)
+				ctx.Response.WriteHeader(http.StatusNotModified)
 				return nil
 			}
 		}
 	}
 
-	w.Header().Set("ETag", v.etag)
-	return v.serveContent(w, r)
+	ctx.Response.Header().Set("ETag", v.etag)
+	return v.serveContent(ctx.Response, ctx.Request)
 }
 
 func (v *FileViewer) serveContent(w http.ResponseWriter, r *http.Request) error {

--- a/viewer_file_test.go
+++ b/viewer_file_test.go
@@ -25,8 +25,13 @@ func TestFileViewer(t *testing.T) {
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		w := httptest.NewRecorder()
 
+		ctx := &Context{
+			Request:  r,
+			Response: NewResponseWriter(w),
+		}
+
 		require.Equal(t, "*/*", v.MimeType().String())
-		err := v.Render(w, r, nil)
+		err := v.Render(ctx, nil)
 
 		require.NoError(t, err)
 		etag := w.Header().Get("ETag")
@@ -39,7 +44,12 @@ func TestFileViewer(t *testing.T) {
 
 		w = httptest.NewRecorder()
 
-		err = v.Render(w, r, nil)
+		ctx = &Context{
+			Request:  r,
+			Response: NewResponseWriter(w),
+		}
+
+		err = v.Render(ctx, nil)
 		require.NoError(t, err)
 
 		require.NotEmpty(t, etag)
@@ -50,8 +60,12 @@ func TestFileViewer(t *testing.T) {
 		v := NewFileViewer(fsys, "public/index.html", false)
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		w := httptest.NewRecorder()
+		ctx := &Context{
+			Request:  r,
+			Response: NewResponseWriter(w),
+		}
 
-		err := v.Render(w, r, nil)
+		err := v.Render(ctx, nil)
 
 		require.NoError(t, err)
 		lastModified := w.Header().Get("Last-Modified")
@@ -66,7 +80,12 @@ func TestFileViewer(t *testing.T) {
 
 		w = httptest.NewRecorder()
 
-		err = v.Render(w, r, nil)
+		ctx = &Context{
+			Request:  r,
+			Response: NewResponseWriter(w),
+		}
+
+		err = v.Render(ctx, nil)
 		require.NoError(t, err)
 
 		lastModified = w.Header().Get("Last-Modified")
@@ -80,7 +99,12 @@ func TestFileViewer(t *testing.T) {
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		w := httptest.NewRecorder()
 
-		err := v.Render(w, r, nil)
+		ctx := &Context{
+			Request:  r,
+			Response: NewResponseWriter(w),
+		}
+
+		err := v.Render(ctx, nil)
 
 		require.NoError(t, err)
 		require.Equal(t, http.StatusNotFound, w.Code)
@@ -89,7 +113,12 @@ func TestFileViewer(t *testing.T) {
 		r = httptest.NewRequest(http.MethodGet, "/", nil)
 		w = httptest.NewRecorder()
 
-		err = v.Render(w, r, nil)
+		ctx = &Context{
+			Request:  r,
+			Response: NewResponseWriter(w),
+		}
+
+		err = v.Render(ctx, nil)
 
 		require.NoError(t, err)
 		require.Equal(t, http.StatusNotFound, w.Code)
@@ -117,7 +146,12 @@ func TestFileViewer(t *testing.T) {
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		w := httptest.NewRecorder()
 
-		err := v.Render(w, r, nil)
+		ctx := &Context{
+			Request:  r,
+			Response: NewResponseWriter(w),
+		}
+
+		err := v.Render(ctx, nil)
 
 		require.ErrorIs(t, err, errCannotStat)
 	})

--- a/viewer_html.go
+++ b/viewer_html.go
@@ -34,7 +34,7 @@ func (v *HtmlViewer) Render(ctx *Context, data any) error { // skipcq: RVV-B0012
 		buf := BufPool.Get()
 		defer BufPool.Put(buf)
 
-		err = v.template.Execute(buf, ContextData{Context: ctx, Data: data})
+		err = v.template.Execute(buf, ViewModel{TempData: ctx.TempData, Data: data})
 		if err != nil {
 			return err
 		}

--- a/viewer_html.go
+++ b/viewer_html.go
@@ -27,10 +27,10 @@ func (*HtmlViewer) MimeType() *MimeType {
 //
 // This implementation uses the `HtmlTemplate.Execute` method to render the template.
 // The rendered result is written to the http.ResponseWriter.
-func (v *HtmlViewer) Render(w http.ResponseWriter, r *http.Request, data any) error { // skipcq: RVV-B0012
+func (v *HtmlViewer) Render(ctx *Context, data any) error { // skipcq: RVV-B0012
 	var err error
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if r.Method != http.MethodHead {
+	ctx.Response.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if ctx.Request.Method != http.MethodHead {
 		buf := BufPool.Get()
 		defer BufPool.Put(buf)
 
@@ -38,7 +38,7 @@ func (v *HtmlViewer) Render(w http.ResponseWriter, r *http.Request, data any) er
 		if err != nil {
 			return err
 		}
-		_, err = buf.WriteTo(w)
+		_, err = buf.WriteTo(ctx.Response)
 	}
 	return err
 }

--- a/viewer_html.go
+++ b/viewer_html.go
@@ -34,7 +34,7 @@ func (v *HtmlViewer) Render(ctx *Context, data any) error { // skipcq: RVV-B0012
 		buf := BufPool.Get()
 		defer BufPool.Put(buf)
 
-		err = v.template.Execute(buf, data)
+		err = v.template.Execute(buf, ContextData{Context: ctx, Data: data})
 		if err != nil {
 			return err
 		}

--- a/viewer_html_test.go
+++ b/viewer_html_test.go
@@ -24,6 +24,14 @@ func TestInvalidHtmlTemplate(t *testing.T) {
 		},
 	}
 
-	err = v.Render(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil), Data{})
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+
+	ctx := &Context{
+		Request:  r,
+		Response: NewResponseWriter(w),
+	}
+
+	err = v.Render(ctx, Data{})
 	require.NotNil(t, err)
 }

--- a/viewer_json.go
+++ b/viewer_json.go
@@ -22,10 +22,10 @@ func (*JsonViewer) MimeType() *MimeType {
 // Render renders the given data as JSON to the http.ResponseWriter.
 //
 // It sets the Content-Type header to "application/json".
-func (*JsonViewer) Render(w http.ResponseWriter, r *http.Request, data any) error { // skipcq: RVV-B0012
+func (*JsonViewer) Render(ctx *Context, data any) error { // skipcq: RVV-B0012
 	var err error
-	w.Header().Set("Content-Type", "application/json")
-	if r.Method != http.MethodHead {
+	ctx.Response.Header().Set("Content-Type", "application/json")
+	if ctx.Request.Method != http.MethodHead {
 		buf := BufPool.Get()
 		defer BufPool.Put(buf)
 
@@ -33,7 +33,7 @@ func (*JsonViewer) Render(w http.ResponseWriter, r *http.Request, data any) erro
 		if err != nil {
 			return err
 		}
-		_, err = buf.WriteTo(w)
+		_, err = buf.WriteTo(ctx.Response)
 	}
 
 	return err

--- a/viewer_json_test.go
+++ b/viewer_json_test.go
@@ -13,17 +13,31 @@ func TestJsonViewerRenderError(t *testing.T) {
 
 	data := make(chan int)
 
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
 	rw := httptest.NewRecorder()
 	rw.Code = -1
 
+	ctx := &Context{
+		Request:  r,
+		Response: NewResponseWriter(rw),
+	}
+
 	// should get raw error when json.marshal fails, and StatusCode should be written
-	err := v.Render(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil), data)
+	err := v.Render(ctx, data)
 	require.Error(t, err)
 	require.Equal(t, "chan int is unsupported type", err.Error())
 
 	require.Equal(t, -1, rw.Code)
 
-	err = v.Render(rw, httptest.NewRequest(http.MethodGet, "/", nil), "")
+	r = httptest.NewRequest(http.MethodGet, "/", nil)
+	rw = httptest.NewRecorder()
+
+	ctx = &Context{
+		Request:  r,
+		Response: NewResponseWriter(rw),
+	}
+
+	err = v.Render(ctx, "")
 	require.NoError(t, err)
 	require.Equal(t, 200, rw.Code)
 

--- a/viewer_string.go
+++ b/viewer_string.go
@@ -23,15 +23,15 @@ func (*StringViewer) MimeType() *MimeType {
 // Render renders the given data as string to the http.ResponseWriter.
 //
 // It sets the Content-Type header to "text/plain; charset=utf-8".
-func (*StringViewer) Render(w http.ResponseWriter, r *http.Request, data any) error { // skipcq: RVV-B0012
+func (*StringViewer) Render(ctx *Context, data any) error { // skipcq: RVV-B0012
 	var err error
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	ctx.Response.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	if data == nil {
 		return nil
 	}
 
-	if r.Method != http.MethodHead {
-		_, err = fmt.Fprint(w, data)
+	if ctx.Request.Method != http.MethodHead {
+		_, err = fmt.Fprint(ctx.Response, data)
 	}
 
 	return err

--- a/viewer_string_test.go
+++ b/viewer_string_test.go
@@ -16,10 +16,16 @@ func TestStringViewer(t *testing.T) {
 
 	t.Run("nil_should_be_skipped", func(t *testing.T) {
 
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		rw := httptest.NewRecorder()
 		rw.Code = -1
 
-		err := v.Render(rw, httptest.NewRequest(http.MethodGet, "/", nil), nil)
+		ctx := &Context{
+			Request:  r,
+			Response: NewResponseWriter(rw),
+		}
+
+		err := v.Render(ctx, nil)
 		require.NoError(t, err)
 		require.Equal(t, -1, rw.Code) // error StatusCode should not be written by StringViewer
 		require.Equal(t, "text/plain; charset=utf-8", rw.Header().Get("Content-Type"))
@@ -37,10 +43,16 @@ func TestStringViewer(t *testing.T) {
 			Name:  "xun",
 			Since: 2025,
 		}
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		rw := httptest.NewRecorder()
 		rw.Code = -1
 
-		err := v.Render(rw, httptest.NewRequest(http.MethodGet, "/", nil), data)
+		ctx := &Context{
+			Request:  r,
+			Response: NewResponseWriter(rw),
+		}
+
+		err := v.Render(ctx, data)
 		require.NoError(t, err)
 		require.Equal(t, 200, rw.Code)
 		require.Equal(t, "text/plain; charset=utf-8", rw.Header().Get("Content-Type"))

--- a/viewer_text.go
+++ b/viewer_text.go
@@ -28,7 +28,7 @@ func (v *TextViewer) Render(ctx *Context, data any) error { // skipcq: RVV-B0012
 		buf := BufPool.Get()
 		defer BufPool.Put(buf)
 
-		err = v.template.Execute(buf, data)
+		err = v.template.Execute(buf, ContextData{Context: ctx, Data: data})
 		if err != nil {
 			return err
 		}

--- a/viewer_text.go
+++ b/viewer_text.go
@@ -21,10 +21,10 @@ func (v *TextViewer) MimeType() *MimeType {
 // Render writes the text content rendered by the TextViewer to the provided http.ResponseWriter.
 // It sets the Content-Type header to "text/plain; charset=utf-8" and writes the rendered content to the response.
 // If there is an error executing the template, it is returned.
-func (v *TextViewer) Render(w http.ResponseWriter, r *http.Request, data any) error { // skipcq: RVV-B0012
+func (v *TextViewer) Render(ctx *Context, data any) error { // skipcq: RVV-B0012
 	var err error
-	w.Header().Set("Content-Type", v.template.mime.String()+v.template.charset)
-	if r.Method != http.MethodHead {
+	ctx.Response.Header().Set("Content-Type", v.template.mime.String()+v.template.charset)
+	if ctx.Request.Method != http.MethodHead {
 		buf := BufPool.Get()
 		defer BufPool.Put(buf)
 
@@ -33,7 +33,7 @@ func (v *TextViewer) Render(w http.ResponseWriter, r *http.Request, data any) er
 			return err
 		}
 
-		_, err = buf.WriteTo(w)
+		_, err = buf.WriteTo(ctx.Response)
 	}
 
 	return err

--- a/viewer_text.go
+++ b/viewer_text.go
@@ -28,7 +28,7 @@ func (v *TextViewer) Render(ctx *Context, data any) error { // skipcq: RVV-B0012
 		buf := BufPool.Get()
 		defer BufPool.Put(buf)
 
-		err = v.template.Execute(buf, ContextData{Context: ctx, Data: data})
+		err = v.template.Execute(buf, ViewModel{TempData: ctx.TempData, Data: data})
 		if err != nil {
 			return err
 		}

--- a/viewer_text_test.go
+++ b/viewer_text_test.go
@@ -22,6 +22,11 @@ func TestInvalidTextTemplate(t *testing.T) {
 		template: NewTextTemplate(l),
 	}
 
-	err = v.Render(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil), Data{})
+	ctx := &Context{
+		Request:  httptest.NewRequest(http.MethodGet, "/", nil),
+		Response: NewResponseWriter(httptest.NewRecorder()),
+	}
+
+	err = v.Render(ctx, Data{})
 	require.NotNil(t, err)
 }

--- a/viewer_xml.go
+++ b/viewer_xml.go
@@ -23,10 +23,10 @@ func (*XmlViewer) MimeType() *MimeType {
 // Render renders the given data as xml to the http.ResponseWriter.
 //
 // It sets the Content-Type header to "text/xml; charset=utf-8".
-func (*XmlViewer) Render(w http.ResponseWriter, r *http.Request, data any) error { // skipcq: RVV-B0012
+func (*XmlViewer) Render(ctx *Context, data any) error { // skipcq: RVV-B0012
 	var err error
-	w.Header().Set("Content-Type", "text/xml; charset=utf-8")
-	if r.Method != http.MethodHead {
+	ctx.Response.Header().Set("Content-Type", "text/xml; charset=utf-8")
+	if ctx.Request.Method != http.MethodHead {
 		buf := BufPool.Get()
 		defer BufPool.Put(buf)
 
@@ -34,7 +34,7 @@ func (*XmlViewer) Render(w http.ResponseWriter, r *http.Request, data any) error
 		if err != nil {
 			return err
 		}
-		_, err = buf.WriteTo(w)
+		_, err = buf.WriteTo(ctx.Response)
 	}
 
 	return err

--- a/viewer_xml_test.go
+++ b/viewer_xml_test.go
@@ -14,16 +14,30 @@ func TestXmlViewerRenderError(t *testing.T) {
 
 	data := make(chan int)
 
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
 	rw := httptest.NewRecorder()
 	rw.Code = -1
+
+	ctx := &Context{
+		Request:  r,
+		Response: NewResponseWriter(rw),
+	}
+
 	// should get raw error when xml.marshal fails, and StatusCode should be written
-	err := v.Render(rw, httptest.NewRequest(http.MethodGet, "/", nil), data)
+	err := v.Render(ctx, data)
 
 	_, ok := err.(*xml.UnsupportedTypeError)
 	require.True(t, ok)
 	require.Equal(t, -1, rw.Code)
 
-	err = v.Render(rw, httptest.NewRequest(http.MethodGet, "/", nil), "")
+	r = httptest.NewRequest(http.MethodGet, "/", nil)
+	rw = httptest.NewRecorder()
+	ctx = &Context{
+		Request:  r,
+		Response: NewResponseWriter(rw),
+	}
+
+	err = v.Render(ctx, "")
 	require.NoError(t, err)
 	require.Equal(t, 200, rw.Code)
 


### PR DESCRIPTION
### Changed
- !fix(viewer): update Render with `func(*Context,any) error` in `Viewer`. It brings `Context` into t`emplate.Bind` 

### Fixed
-

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Pass the `*Context` object to viewer `Render` methods, enabling access to request and response information within viewers. Update the contribution guidelines to use the Apache 2.0 license and add badges to the README.

Enhancements:
- Pass `*Context` to the `Render` methods of all viewers.
- Update `Context` to use `Values` instead of `values`.
- Use `*Context` in `app.HandleFile` and `app.HandlePage` handlers.
- Refactor tests to use `*Context` when calling viewer `Render` methods

Documentation:
- Update the contribution guidelines to reflect the Apache 2.0 license.
- Add badges for issues and pull requests to the README.
- Clarify the pronunciation of Xun in the README