### PR TITLE
fix(htmx): added htmx.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -993,7 +993,7 @@ The library to enable seamless integration between native JavaScript methods and
 #### 5. Setup Hx-Trigger listener
 > app.js
 ```js
-$x.ready(function(evt) {
+xun.ready(function(evt) {
 	document.body.addEventListener("showMessage", function(evt){
     alert(evt.detail.value);
   })

--- a/README.md
+++ b/README.md
@@ -907,7 +907,8 @@ Add your compiled CSS file to the `assets.html` and start using Tailwind’s uti
 │   ├── tailwind.css
 ```
 
-#### 2. Serve [htmx-ext.js](./ext/htmx/htmx.js) to seamlessly integrate htmx.js into your Go web application.
+#### 2. Serve [htmx-ext.js](./ext/htmx/htmx.js) library
+The library to enable seamless integration between native JavaScript methods and htmx features, enhancing interactive capabilities without compromising core functionality.
 
 ```go
 	app.Get("/htmx-ext.js", htmx.HandleFunc())

--- a/README.md
+++ b/README.md
@@ -907,8 +907,8 @@ Add your compiled CSS file to the `assets.html` and start using Tailwind’s uti
 │   ├── tailwind.css
 ```
 
-#### 2. Serve htmx-ext.js to seamlessly integrate htmx.js into your Go web application.
-check more [apis](./ext/htmx/htmx.js)
+#### 2. Serve [htmx-ext.js](./ext/htmx/htmx.js) to seamlessly integrate htmx.js into your Go web application.
+
 ```go
 	app.Get("/htmx-ext.js", htmx.HandleFunc())
 ```
@@ -1069,7 +1069,9 @@ create an `admin` group router, and apply a middleware to check if it's logged. 
 
 		http.SetCookie(c.Response, &cookie)
 
-		c.Redirect(c.RequestReferer().Query().Get("return"))
+    u, _ := url.Parse(c.RequestReferer())
+
+		c.Redirect(u.Query().Get("return"))
 		return nil
 	})
 ```

--- a/README.md
+++ b/README.md
@@ -907,14 +907,21 @@ Add your compiled CSS file to the `assets.html` and start using Tailwind’s uti
 │   ├── tailwind.css
 ```
 
-#### Install htmx.js
+#### serve htmx-ext.js to seamlessly integrate htmx.js into your Go web application.
+check more [apis](./ext/htmx/htmx-ext.js)
+```go
+	app.Get("/htmx-ext.js", htmx.HandleFunc())
+```
+
+#### Install  htmx.js and htmx-ext.js
 
 > components/assets.html
 ```html
 <link rel="stylesheet" href="/skin.css">
 <link rel="stylesheet" href="/theme.css">
 <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
-<script type="text/javascript" src="/app.js"></script>
+<script type="text/javascript" src="/htmx-ext.js"></script>
+<script type="text/javascript" src="/app.js" defer></script>
 ```
 
 #### Enabled `htmx` feature on pages
@@ -985,8 +992,8 @@ Add your compiled CSS file to the `assets.html` and start using Tailwind’s uti
 #### Setup Hx-Trigger listener
 > app.js
 ```js
-window.addEventListener("DOMContentLoaded", (event) => {
-  document.body.addEventListener("showMessage", function(evt){
+$x.ready(function(evt) {
+	document.body.addEventListener("showMessage", function(evt){
     alert(evt.detail.value);
   })
 });

--- a/README.md
+++ b/README.md
@@ -833,13 +833,13 @@ func main() {
 
 
 ### Works with [tailwindcss](https://tailwindcss.com/docs/installation)
-#### Install Tailwind CSS
+#### 1. Install Tailwind CSS
 Install tailwindcss via npm, and create your tailwind.config.js file.
 ```bash
 npm install -D tailwindcss
 npx tailwindcss init
 ```
-#### Configure your template paths
+#### 2. Configure your template paths
 Add the paths to all of your template files in your tailwind.config.js file.
 
 > tailwind.config.js
@@ -854,7 +854,7 @@ module.exports = {
 }
 ```
 
-#### Add the Tailwind directives to your CSS
+#### 3. Add the Tailwind directives to your CSS
 Add the @tailwind directives for each of Tailwind’s layers to your main CSS file.
 > app/tailwind.css
 ```css
@@ -863,14 +863,14 @@ Add the @tailwind directives for each of Tailwind’s layers to your main CSS fi
 @tailwind utilities;
 ```
 
-#### Start the Tailwind CLI build process
+#### 4. Start the Tailwind CLI build process
 Run the CLI tool to scan your template files for classes and build your CSS.
 
 ```bash
 npx tailwindcss -i ./app/tailwind.css -o ./app/public/theme.css --watch
 ```
 
-#### Start using Tailwind in your HTML
+#### 5. Start using Tailwind in your HTML
 Add your compiled CSS file to the `assets.html` and start using Tailwind’s utility classes to style your content.
 
 > components/assets.html
@@ -881,7 +881,7 @@ Add your compiled CSS file to the `assets.html` and start using Tailwind’s uti
 ```
 
 ### Works with [htmx.js](https://htmx.org/docs/)
-#### Add new pages
+#### 1. Add new pages
 > `pages/admin/index.html` and `pages/login.html`
 ```
 ├── app
@@ -907,13 +907,13 @@ Add your compiled CSS file to the `assets.html` and start using Tailwind’s uti
 │   ├── tailwind.css
 ```
 
-#### serve htmx-ext.js to seamlessly integrate htmx.js into your Go web application.
-check more [apis](./ext/htmx/htmx-ext.js)
+#### 2. Serve htmx-ext.js to seamlessly integrate htmx.js into your Go web application.
+check more [apis](./ext/htmx/htmx.js)
 ```go
 	app.Get("/htmx-ext.js", htmx.HandleFunc())
 ```
 
-#### Install  htmx.js and htmx-ext.js
+#### 3. Install htmx.js and htmx-ext.js
 
 > components/assets.html
 ```html
@@ -924,7 +924,7 @@ check more [apis](./ext/htmx/htmx-ext.js)
 <script type="text/javascript" src="/app.js" defer></script>
 ```
 
-#### Enabled `htmx` feature on pages
+#### 4. Enabled `htmx` feature on pages
 > pages/index.html
 ```html
 <!--layout:home-->
@@ -989,7 +989,7 @@ check more [apis](./ext/htmx/htmx-ext.js)
 {{ end }}
 ```
 
-#### Setup Hx-Trigger listener
+#### 5. Setup Hx-Trigger listener
 > app.js
 ```js
 $x.ready(function(evt) {
@@ -1000,14 +1000,14 @@ $x.ready(function(evt) {
 
 ```
 
-#### Apply `htmx` interceptor 
+#### 6. Apply `htmx` interceptor 
 ```go
 
 	app := xun.New(xun.WithInterceptor(htmx.New()))
 
 ```
 
-#### Create router handler to process request
+#### 7. Create router handler to process request
 create an `admin` group router, and apply a middleware to check if it's logged. if not, redirect to /login.
 
 

--- a/etag.go
+++ b/etag.go
@@ -1,7 +1,7 @@
 package xun
 
 import (
-	"crypto/md5" // skipcq: GSC-G401, GO-S1023
+	"crypto/md5" // skipcq: GSC-G401, GSC-G501, GO-S1023
 	"encoding/hex"
 	"hash"
 	"io"
@@ -10,18 +10,16 @@ import (
 	"strings"
 )
 
-// ComputeEtag returns the ETag header value for the given reader content.
+// ComputeETag returns the ETag header value for the given reader content.
 //
-// The value is computed by taking the SHA256 of the content and encoding it
+// The value is computed by taking the md5 of the content and encoding it
 // as a hexadecimal string.
 func ComputeETag(r io.Reader) string {
-	return ComputeETagWith(r, md5.New()) // skipcq: GSC-G401, GO-S1023
+	return ComputeETagWith(r, md5.New()) // skipcq: GSC-G401, GSC-G501, GO-S1023
 }
 
-// ComputeEtag returns the ETag header value for the given reader content.
-//
-// The value is computed by taking the SHA256 of the content and encoding it
-// as a hexadecimal string.
+// ComputeETagWith returns the ETag header value for the given reader content
+// using the provided hash function.
 func ComputeETagWith(r io.Reader, h hash.Hash) string {
 	if _, err := io.Copy(h, r); err != nil {
 		return ""

--- a/etag.go
+++ b/etag.go
@@ -1,0 +1,122 @@
+package xun
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"hash"
+	"io"
+	"net/http"
+	"net/textproto"
+	"strings"
+)
+
+// ComputesEtag returns the ETag header value for the given reader content.
+//
+// The value is computed by taking the SHA256 of the content and encoding it
+// as a hexadecimal string.
+func ComputeEtag(r io.Reader) string {
+	return ComputeEtagWith(r, md5.New())
+}
+
+// ComputesEtag returns the ETag header value for the given reader content.
+//
+// The value is computed by taking the SHA256 of the content and encoding it
+// as a hexadecimal string.
+func ComputeEtagWith(r io.Reader, h hash.Hash) string {
+	if _, err := io.Copy(h, r); err != nil {
+		return ""
+	}
+
+	return `"` + hex.EncodeToString(h.Sum(nil)) + `"`
+}
+
+func WriteNotModifiedForTag(w http.ResponseWriter, r *http.Request) bool {
+	if r.Method == "GET" || r.Method == "HEAD" {
+		if CheckIfNoneMatch(w, r) {
+			WriteNotModified(w)
+			return true
+		}
+	}
+
+	return false
+}
+
+func CheckIfNoneMatch(w http.ResponseWriter, r *http.Request) bool {
+	inm := r.Header.Get("If-None-Match")
+	if inm == "" {
+		return false
+	}
+	buf := inm
+	for {
+		buf = textproto.TrimString(buf)
+		if len(buf) == 0 {
+			break
+		}
+		if buf[0] == ',' {
+			buf = buf[1:]
+			continue
+		}
+		if buf[0] == '*' {
+			return true
+		}
+		etag, remain := ScanETag(buf)
+		if etag == "" {
+			break
+		}
+		if EtagWeakMatch(etag, w.Header().Get("Etag")) {
+			return true
+		}
+		buf = remain
+	}
+	return false
+}
+
+// scanETag determines if a syntactically valid ETag is present at s. If so,
+// the ETag and remaining text after consuming ETag is returned. Otherwise,
+// it returns "", "".
+func ScanETag(s string) (etag string, remain string) {
+	s = textproto.TrimString(s)
+	start := 0
+	if strings.HasPrefix(s, "W/") {
+		start = 2
+	}
+	if len(s[start:]) < 2 || s[start] != '"' {
+		return "", ""
+	}
+	// ETag is either W/"text" or "text".
+	// See RFC 7232 2.3.
+	for i := start + 1; i < len(s); i++ {
+		c := s[i]
+		switch {
+		// Character values allowed in ETags.
+		case c == 0x21 || c >= 0x23 && c <= 0x7E || c >= 0x80:
+		case c == '"':
+			return s[:i+1], s[i+1:]
+		default:
+			return "", ""
+		}
+	}
+	return "", ""
+}
+
+// etagWeakMatch reports whether a and b match using weak ETag comparison.
+// Assumes a and b are valid ETags.
+func EtagWeakMatch(a, b string) bool {
+	return strings.TrimPrefix(a, "W/") == strings.TrimPrefix(b, "W/")
+}
+
+func WriteNotModified(w http.ResponseWriter) {
+	// RFC 7232 section 4.1:
+	// a sender SHOULD NOT generate representation metadata other than the
+	// above listed fields unless said metadata exists for the purpose of
+	// guiding cache updates (e.g., Last-Modified might be useful if the
+	// response does not have an ETag field).
+	h := w.Header()
+	delete(h, "Content-Type")
+	delete(h, "Content-Length")
+	delete(h, "Content-Encoding")
+	if h.Get("Etag") != "" {
+		delete(h, "Last-Modified")
+	}
+	w.WriteHeader(http.StatusNotModified)
+}

--- a/etag_test.go
+++ b/etag_test.go
@@ -1,0 +1,85 @@
+package xun
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestETag(t *testing.T) {
+
+	t.Run("tag", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		w := httptest.NewRecorder()
+
+		require.True(t, !WriteIfNoneMatch(w, req))
+
+		req.Header.Set("If-None-Match", "\"737060cd8c284d8af7ad3082f209582d\"")
+		require.True(t, !WriteIfNoneMatch(w, req))
+
+		w.Header().Set("ETag", "\"737060cd8c284d8af7ad3082f209582d\"")
+		require.True(t, WriteIfNoneMatch(w, req))
+	})
+
+	t.Run("weak_tag", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		w := httptest.NewRecorder()
+
+		require.True(t, !WriteIfNoneMatch(w, req))
+
+		req.Header.Set("If-None-Match", "W/\"737060cd8c284d8af7ad3082f209582d\"")
+		require.True(t, !WriteIfNoneMatch(w, req))
+
+		w.Header().Set("ETag", "W/\"737060cd8c284d8af7ad3082f209582d\"")
+		require.True(t, WriteIfNoneMatch(w, req))
+	})
+
+	t.Run("multi-etags", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+		req.Header.Set("If-None-Match", `"etag1", "etag2", W/"weak-etag"`)
+
+		w.Header().Set("ETag", `"etag1"`)
+		require.True(t, WriteIfNoneMatch(w, req))
+
+		w.Header().Set("ETag", `"etag2"`)
+		require.True(t, WriteIfNoneMatch(w, req))
+
+		w.Header().Set("ETag", `W/"weak-etag"`)
+		require.True(t, WriteIfNoneMatch(w, req))
+	})
+
+	t.Run("any_etags", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+		req.Header.Set("If-None-Match", `*`)
+
+		w.Header().Set("ETag", `"etag1"`)
+		require.True(t, WriteIfNoneMatch(w, req))
+
+		w.Header().Set("ETag", `"etag2"`)
+		require.True(t, WriteIfNoneMatch(w, req))
+
+		w.Header().Set("ETag", `W/"weak-etag"`)
+		require.True(t, WriteIfNoneMatch(w, req))
+	})
+
+	t.Run("invalid_etags", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+		req.Header.Set("If-None-Match", `W\`)
+
+		require.False(t, WriteIfNoneMatch(w, req))
+
+		req.Header.Set("If-None-Match", `""`)
+		require.False(t, WriteIfNoneMatch(w, req))
+
+		req.Header.Set("If-None-Match", `"etag",`)
+		require.False(t, WriteIfNoneMatch(w, req))
+	})
+}

--- a/etag_test.go
+++ b/etag_test.go
@@ -79,7 +79,10 @@ func TestETag(t *testing.T) {
 		req.Header.Set("If-None-Match", `""`)
 		require.False(t, WriteIfNoneMatch(w, req))
 
-		req.Header.Set("If-None-Match", `"etag",`)
+		req.Header.Set("If-None-Match", `"etag "`)
+		require.False(t, WriteIfNoneMatch(w, req))
+
+		req.Header.Set("If-None-Match", `"etag`)
 		require.False(t, WriteIfNoneMatch(w, req))
 	})
 }

--- a/ext/csrf/csrf.go
+++ b/ext/csrf/csrf.go
@@ -5,11 +5,9 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"embed"
-	"encoding/base64"
 	"html/template"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/yaitoo/xun"
@@ -70,6 +68,26 @@ func HandleFunc(secretKey []byte, opts ...Option) xun.HandleFunc {
 		opt(o)
 	}
 
+	buf := loadJavascript(o)
+
+	mac := hmac.New(sha256.New, o.SecretKey)
+	etag := xun.ComputeEtagWith(bytes.NewReader(buf), mac)
+
+	return func(c *xun.Context) error {
+		c.Response.Header().Set("ETag", etag)
+		if xun.WriteNotModifiedForTag(c.Response, c.Request) {
+			return nil
+		}
+
+		content := bytes.NewReader(buf)
+		c.Response.Header().Set("Content-Type", "application/javascript")
+		http.ServeContent(c.Response, c.Request, "csrf.js", zeroTime, content)
+
+		return nil
+	}
+}
+
+func loadJavascript(o *Options) []byte {
 	f, _ := fsys.Open("csrf.js") // nolint: errcheck
 	defer f.Close()
 
@@ -77,29 +95,8 @@ func HandleFunc(secretKey []byte, opts ...Option) xun.HandleFunc {
 
 	t, _ := template.New("token").Parse(string(buf)) // nolint: errcheck
 
-	var processed bytes.Buffer
-	t.Execute(&processed, o) // nolint: errcheck
+	var body bytes.Buffer
+	t.Execute(&body, o) // nolint: errcheck
 
-	mac := hmac.New(sha256.New, o.SecretKey)
-	mac.Write(processed.Bytes())
-
-	etag := base64.URLEncoding.EncodeToString(mac.Sum(nil))
-
-	return func(c *xun.Context) error {
-		if match := c.Request.Header.Get("If-None-Match"); match != "" {
-			for _, it := range strings.Split(match, ",") {
-				if strings.TrimSpace(it) == etag {
-					c.Response.WriteHeader(http.StatusNotModified)
-					return nil
-				}
-			}
-		}
-
-		c.Response.Header().Set("ETag", etag)
-
-		content := bytes.NewReader(processed.Bytes())
-		c.Response.Header().Set("Content-Type", "application/javascript")
-		http.ServeContent(c.Response, c.Request, "csrf.js", zeroTime, content)
-		return nil
-	}
+	return body.Bytes()
 }

--- a/ext/csrf/csrf.go
+++ b/ext/csrf/csrf.go
@@ -68,14 +68,14 @@ func HandleFunc(secretKey []byte, opts ...Option) xun.HandleFunc {
 		opt(o)
 	}
 
-	buf := loadJavascript(o)
+	buf := loadJavaScript(o)
 
 	mac := hmac.New(sha256.New, o.SecretKey)
-	etag := xun.ComputeEtagWith(bytes.NewReader(buf), mac)
+	etag := xun.ComputeETagWith(bytes.NewReader(buf), mac)
 
 	return func(c *xun.Context) error {
 		c.Response.Header().Set("ETag", etag)
-		if xun.WriteNotModifiedForTag(c.Response, c.Request) {
+		if xun.WriteIfNoneMatch(c.Response, c.Request) {
 			return nil
 		}
 
@@ -87,7 +87,7 @@ func HandleFunc(secretKey []byte, opts ...Option) xun.HandleFunc {
 	}
 }
 
-func loadJavascript(o *Options) []byte {
+func loadJavaScript(o *Options) []byte {
 	f, _ := fsys.Open("csrf.js") // nolint: errcheck
 	defer f.Close()
 

--- a/ext/csrf/csrf_test.go
+++ b/ext/csrf/csrf_test.go
@@ -172,7 +172,7 @@ func TestHandleFunc(t *testing.T) {
 			CookieName: "test_token",
 		})
 
-		etag := xun.ComputeEtagWith(&body, hmac.New(sha256.New, []byte("secret")))
+		etag := xun.ComputeETagWith(&body, hmac.New(sha256.New, []byte("secret")))
 
 		w := httptest.NewRecorder()
 		ctx := &xun.Context{

--- a/ext/csrf/csrf_test.go
+++ b/ext/csrf/csrf_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
-	"encoding/base64"
 	"html/template"
 	"io"
 	"net/http"
@@ -166,17 +165,14 @@ func TestHandleFunc(t *testing.T) {
 
 		p, _ := template.New("token").Parse(string(buf)) // nolint: errcheck
 
-		var processed bytes.Buffer
+		var body bytes.Buffer
 		// nolint: errcheck
-		p.Execute(&processed, &Options{
+		p.Execute(&body, &Options{
 			SecretKey:  []byte("secret"),
 			CookieName: "test_token",
 		})
 
-		mac := hmac.New(sha256.New, []byte("secret"))
-		mac.Write(processed.Bytes())
-
-		etag := base64.URLEncoding.EncodeToString(mac.Sum(nil))
+		etag := xun.ComputeEtagWith(&body, hmac.New(sha256.New, []byte("secret")))
 
 		w := httptest.NewRecorder()
 		ctx := &xun.Context{

--- a/ext/htmx/htmx.go
+++ b/ext/htmx/htmx.go
@@ -93,12 +93,12 @@ var zeroTime time.Time
 
 // HandleFunc serves the htmx.js library for the htmx extension.
 func HandleFunc() xun.HandleFunc {
-	buf := loadJavascript()
-	etag := xun.ComputeEtag(bytes.NewReader(buf))
+	buf := loadJavaScript()
+	etag := xun.ComputeETag(bytes.NewReader(buf))
 
 	return func(c *xun.Context) error {
 		c.Response.Header().Set("ETag", etag)
-		if xun.WriteNotModifiedForTag(c.Response, c.Request) {
+		if xun.WriteIfNoneMatch(c.Response, c.Request) {
 			return nil
 		}
 
@@ -109,7 +109,7 @@ func HandleFunc() xun.HandleFunc {
 	}
 }
 
-func loadJavascript() []byte {
+func loadJavaScript() []byte {
 	f, _ := fsys.Open("htmx.js") // nolint: errcheck
 	defer f.Close()
 

--- a/ext/htmx/htmx.js
+++ b/ext/htmx/htmx.js
@@ -1,4 +1,4 @@
-window.$x = window.$x || {
+window.xun = window.xun || {
   /**
    * A global object to manage custom events and callbacks.
    *

--- a/ext/htmx/htmx.js
+++ b/ext/htmx/htmx.js
@@ -20,6 +20,7 @@ window.$x = window.$x || {
         }
       });  
       document.addEventListener('htmx:beforeOnLoad', function(evt) {
+        // trigger ready function again when a boosted request is done
         boosted = evt.detail.boosted;
       });
     }

--- a/ext/htmx/htmx.js
+++ b/ext/htmx/htmx.js
@@ -1,0 +1,26 @@
+window.$x = window.$x || {
+  /**
+   * A global object to manage custom events and callbacks.
+   *
+   * @property {Function} ready - Registers a callback function to be executed once when 
+   * the DOM is fully loaded or when an `htmx:load` event occurs.
+   * 
+   * @function ready
+   * @param {Function} fn - The callback function to be executed.
+   */
+    ready:function(fn){
+      let boosted = false;
+      document.addEventListener('DOMContentLoaded',function(){
+        fn();
+      });
+      document.addEventListener('htmx:load', function(evt) {
+        if(boosted){
+          fn(evt);
+          boosted = false;  
+        }
+      });  
+      document.addEventListener('htmx:beforeOnLoad', function(evt) {
+        boosted = evt.detail.boosted;
+      });
+    }
+  }

--- a/ext/htmx/htmx_test.go
+++ b/ext/htmx/htmx_test.go
@@ -102,7 +102,7 @@ func TestHandleFunc(t *testing.T) {
 		// nolint: errcheck
 		p.Execute(&body, nil)
 
-		etag := xun.ComputeEtag(&body)
+		etag := xun.ComputeETag(&body)
 
 		w := httptest.NewRecorder()
 		ctx := &xun.Context{

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-playground/form/v4 v4.2.1
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
-	github.com/go-playground/validator/v10 v10.24.0
+	github.com/go-playground/validator/v10 v10.25.0
 	github.com/json-iterator/go v1.1.12
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.33.0
@@ -19,7 +19,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/o
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
-github.com/go-playground/validator/v10 v10.24.0 h1:KHQckvo8G6hlWnrPX4NJJ+aBfWNAE/HH+qdL2cBpCmg=
-github.com/go-playground/validator/v10 v10.24.0/go.mod h1:GGzBIJMuE98Ic/kJsBXbz1x/7cByt++cQ+YOuDM5wus=
+github.com/go-playground/validator/v10 v10.25.0 h1:5Dh7cjvzR7BRZadnsVOzPhWsrwUr0nmsZJxEAnFLNO8=
+github.com/go-playground/validator/v10 v10.25.0/go.mod h1:GGzBIJMuE98Ic/kJsBXbz1x/7cByt++cQ+YOuDM5wus=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -29,8 +29,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=

--- a/viewer_file.go
+++ b/viewer_file.go
@@ -21,7 +21,7 @@ func NewFileViewer(fsys fs.FS, path string, isEmbed bool) *FileViewer {
 		defer f.Close()
 
 		v.isEmbed = true
-		v.etag = ComputeEtag(f)
+		v.etag = ComputeETag(f)
 	}
 
 	return v
@@ -69,7 +69,7 @@ func (v *FileViewer) Render(ctx *Context, data any) error {
 	}
 
 	ctx.Response.Header().Set("ETag", v.etag)
-	if WriteNotModifiedForTag(ctx.Response, ctx.Request) {
+	if WriteIfNoneMatch(ctx.Response, ctx.Request) {
 		return nil
 	}
 

--- a/viewer_file.go
+++ b/viewer_file.go
@@ -1,12 +1,9 @@
 package xun
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"io"
 	"io/fs"
 	"net/http"
-	"strings"
 )
 
 // NewFileViewer creates a new FileViewer instance.
@@ -23,12 +20,8 @@ func NewFileViewer(fsys fs.FS, path string, isEmbed bool) *FileViewer {
 		}
 		defer f.Close()
 
-		hash := sha256.New() // skipcq: GSC-G401, GO-S1023
-		if _, err := io.Copy(hash, f); err != nil {
-			return v
-		}
 		v.isEmbed = true
-		v.etag = `"` + hex.EncodeToString(hash.Sum(nil)) + `"`
+		v.etag = ComputeEtag(f)
 	}
 
 	return v
@@ -74,16 +67,12 @@ func (v *FileViewer) Render(ctx *Context, data any) error {
 	if !v.isEmbed {
 		return v.serveContent(ctx.Response, ctx.Request)
 	}
-	if match := ctx.Request.Header.Get("If-None-Match"); match != "" {
-		for _, it := range strings.Split(match, ",") {
-			if strings.TrimSpace(it) == v.etag {
-				ctx.Response.WriteHeader(http.StatusNotModified)
-				return nil
-			}
-		}
-	}
 
 	ctx.Response.Header().Set("ETag", v.etag)
+	if WriteNotModifiedForTag(ctx.Response, ctx.Request) {
+		return nil
+	}
+
 	return v.serveContent(ctx.Response, ctx.Request)
 }
 


### PR DESCRIPTION
### Changed
-

### Fixed
-

### Added
- fix(htmx): added `htmx.js` libraries to help htmx development.

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

This pull request adds the `htmx.js` library and enhances caching for HTMX and CSRF JavaScript files by implementing ETag support. It also includes a new `$x.ready()` function that executes callbacks when the DOM is loaded or when an `htmx:load` event occurs.

New Features:
- Adds the `htmx.js` library to provide client-side support for HTMX development, including a `$x.ready()` function that executes callbacks when the DOM is loaded or when an `htmx:load` event occurs.

Enhancements:
- Improves HTTP caching by adding ETag support to the HTMX and CSRF handlers, preventing unnecessary data transfer when the client already has the latest version of the JavaScript files.
- Refactors the CSRF handler to use a common function for loading JavaScript and computing ETags.

Tests:
- Adds tests for the HTMX handler to verify that it serves the `htmx.js` library correctly and returns a 304 status code when the ETag matches.