### PR TITLE
fix(htmx): added `selector` in `xun.ready` to check if the callback should be executed

### DIFF
--- a/ext/htmx/htmx.js
+++ b/ext/htmx/htmx.js
@@ -6,16 +6,26 @@ window.xun = window.xun || {
    * the DOM is fully loaded or when an `htmx:load` event occurs.
    * 
    * @function ready
-   * @param {Function} fn - The callback function to be executed.
+   * @param {Function} callback - The callback function to be executed.
+   * @param {String} selector - The selector to be used to check if the callback should be triggered.
    */
-    ready:function(fn){
+    ready:function(callback,selector){
+      const f = function(evt){
+       if(selector){
+        if(document.querySelector(selector)){
+          callback(evt);
+        }
+       }else{
+        callback(evt);
+       }
+      }
       let boosted = false;
-      document.addEventListener('DOMContentLoaded',function(){
-        fn();
+      document.addEventListener('DOMContentLoaded',function(evt){
+        f(evt);
       });
       document.addEventListener('htmx:load', function(evt) {
         if(boosted){
-          fn(evt);
+          f(evt);
           boosted = false;  
         }
       });  

--- a/ext/htmx/htmx.js
+++ b/ext/htmx/htmx.js
@@ -7,7 +7,7 @@ window.xun = window.xun || {
    * 
    * @function ready
    * @param {Function} callback - The callback function to be executed.
-   * @param {String} selector - The selector to be used to check if the callback should be triggered.
+   * @param {String} selector - The selector to be used to check if the callback should be executed.
    */
     ready:function(callback,selector){
       const f = function(evt){


### PR DESCRIPTION
### Changed
-

### Fixed
- fix(htmx): added `selector` in `xun.ready` to check if the callback should be executed.

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Bug Fixes:
- Add a `selector` parameter to the `xun.ready` function in htmx.js to ensure the callback is executed only when the specified selector is present.