### PR TITLE
fix(json): use std json instead of json-iterator to support omitzero

### DIFF
--- a/README.md
+++ b/README.md
@@ -994,10 +994,10 @@ The library to enable seamless integration between native JavaScript methods and
 > app.js
 ```js
 xun.ready(function(evt) {
-	document.body.addEventListener("showMessage", function(evt){
+	document.addEventListener("showMessage", function(evt){
     alert(evt.detail.value);
   })
-});
+},'body');
 
 ```
 

--- a/app_test.go
+++ b/app_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
@@ -704,7 +705,7 @@ func TestDataBindOnHtml(t *testing.T) {
 	resp.Body.Close()
 
 	var list []User
-	err = Json.Unmarshal(buf, &list)
+	err = json.Unmarshal(buf, &list)
 	require.NoError(t, err)
 
 	require.Equal(t, len(list), 3)

--- a/app_test.go
+++ b/app_test.go
@@ -80,7 +80,7 @@ func TestJsonViewer(t *testing.T) {
 	resp, err := client.Do(req)
 	require.NoError(t, err)
 
-	err = json.NewDecoder(resp.Body).Decode(data)
+	err = Json.NewDecoder(resp.Body).Decode(data)
 	require.NoError(t, err)
 	resp.Body.Close()
 
@@ -92,7 +92,7 @@ func TestJsonViewer(t *testing.T) {
 	resp, err = client.Do(req)
 	require.NoError(t, err)
 
-	err = json.NewDecoder(resp.Body).Decode(&data)
+	err = Json.NewDecoder(resp.Body).Decode(&data)
 	require.NoError(t, err)
 	resp.Body.Close()
 	require.Equal(t, "POST", data.Method)
@@ -103,7 +103,7 @@ func TestJsonViewer(t *testing.T) {
 	resp, err = client.Do(req)
 	require.NoError(t, err)
 
-	err = json.NewDecoder(resp.Body).Decode(&data)
+	err = Json.NewDecoder(resp.Body).Decode(&data)
 	require.NoError(t, err)
 	resp.Body.Close()
 	require.Equal(t, "PUT", data.Method)
@@ -114,7 +114,7 @@ func TestJsonViewer(t *testing.T) {
 	resp, err = client.Do(req)
 	require.NoError(t, err)
 
-	err = json.NewDecoder(resp.Body).Decode(&data)
+	err = Json.NewDecoder(resp.Body).Decode(&data)
 	require.NoError(t, err)
 	resp.Body.Close()
 	require.Equal(t, "DELETE", data.Method)
@@ -125,7 +125,7 @@ func TestJsonViewer(t *testing.T) {
 	resp, err = client.Do(req)
 	require.NoError(t, err)
 
-	err = json.NewDecoder(resp.Body).Decode(&data)
+	err = Json.NewDecoder(resp.Body).Decode(&data)
 	require.NoError(t, err)
 	resp.Body.Close()
 	require.Equal(t, "HandleFunc", data.Method)
@@ -704,7 +704,7 @@ func TestDataBindOnHtml(t *testing.T) {
 	resp.Body.Close()
 
 	var list []User
-	err = json.Unmarshal(buf, &list)
+	err = Json.Unmarshal(buf, &list)
 	require.NoError(t, err)
 
 	require.Equal(t, len(list), 3)

--- a/compressor_deflate_test.go
+++ b/compressor_deflate_test.go
@@ -101,7 +101,7 @@ func TestDeflateCompressor(t *testing.T) {
 			require.Equal(t, test.contentEncoding, resp.Header.Get("Content-Encoding"))
 
 			data := make(map[string]string)
-			err = json.NewDecoder(test.createReader(resp.Body)).Decode(&data)
+			err = Json.NewDecoder(test.createReader(resp.Body)).Decode(&data)
 			require.NoError(t, err)
 			require.Equal(t, "hello", data["message"])
 		})

--- a/compressor_gzip_test.go
+++ b/compressor_gzip_test.go
@@ -112,7 +112,7 @@ func TestGzipCompressor(t *testing.T) {
 			require.Equal(t, test.contentEncoding, resp.Header.Get("Content-Encoding"))
 
 			data := make(map[string]string)
-			err = json.NewDecoder(test.createReader(resp.Body)).Decode(&data)
+			err = Json.NewDecoder(test.createReader(resp.Body)).Decode(&data)
 			require.NoError(t, err)
 			require.Equal(t, "hello", data["message"])
 		})

--- a/context.go
+++ b/context.go
@@ -3,12 +3,6 @@ package xun
 import (
 	"net/http"
 	"strings"
-
-	jsoniter "github.com/json-iterator/go"
-)
-
-var (
-	json = jsoniter.Config{UseNumber: false}.Froze()
 )
 
 type TempData map[string]any

--- a/context_test.go
+++ b/context_test.go
@@ -71,7 +71,7 @@ func TestTempData(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	var v string
-	err = json.NewDecoder(resp.Body).Decode(&v)
+	err = Json.NewDecoder(resp.Body).Decode(&v)
 	require.NoError(t, err)
 	require.Equal(t, "middleware", v)
 }
@@ -182,7 +182,7 @@ func TestMixedViewers(t *testing.T) {
 			Num  int    `json:"num"`
 		}{}
 
-		err = json.Unmarshal(buf, data)
+		err = Json.Unmarshal(buf, data)
 
 		require.NoError(t, err)
 

--- a/context_test.go
+++ b/context_test.go
@@ -1,6 +1,7 @@
 package xun
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -182,7 +183,7 @@ func TestMixedViewers(t *testing.T) {
 			Num  int    `json:"num"`
 		}{}
 
-		err = Json.Unmarshal(buf, data)
+		err = json.Unmarshal(buf, data)
 
 		require.NoError(t, err)
 

--- a/ext/form/binder.go
+++ b/ext/form/binder.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/go-playground/form/v4"
 	"github.com/go-playground/validator/v10"
-	jsoniter "github.com/json-iterator/go"
+	"github.com/yaitoo/xun"
 )
 
 var (
-	json = jsoniter.Config{UseNumber: false}.Froze()
+	json = xun.Json
 
 	// use a single instance of Decoder, it caches struct info
 	formDecoder = form.NewDecoder()

--- a/ext/form/binder.go
+++ b/ext/form/binder.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	json = xun.Json
+	Json = xun.Json
 
 	// use a single instance of Decoder, it caches struct info
 	formDecoder = form.NewDecoder()
@@ -61,7 +61,7 @@ func BindForm[T any](req *http.Request) (*TEntity[T], error) {
 func BindJson[T any](req *http.Request) (*TEntity[T], error) {
 	data := new(T)
 
-	err := json.NewDecoder(req.Body).Decode(data)
+	err := Json.NewDecoder(req.Body).Decode(data)
 	if err != nil {
 		return nil, err
 	}

--- a/ext/form/binder_test.go
+++ b/ext/form/binder_test.go
@@ -3,6 +3,7 @@ package form
 import (
 	"bytes"
 	"crypto/tls"
+	"encoding/json"
 
 	"net/http"
 	"net/http/httptest"
@@ -135,7 +136,7 @@ func TestBinder(t *testing.T) {
 
 			require.Equal(t, http.StatusOK, resp.StatusCode)
 
-			err = json.NewDecoder(resp.Body).Decode(&result)
+			err = Json.NewDecoder(resp.Body).Decode(&result)
 			require.NoError(t, err)
 			resp.Body.Close()
 			require.Equal(t, "xun@yaitoo.cn", result.Data.Email)
@@ -148,7 +149,7 @@ func TestBinder(t *testing.T) {
 
 			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
-			err = json.NewDecoder(resp.Body).Decode(&result)
+			err = Json.NewDecoder(resp.Body).Decode(&result)
 			require.NoError(t, err)
 			resp.Body.Close()
 			require.Equal(t, "xun@yaitoo.cn", result.Data.Email)
@@ -163,7 +164,7 @@ func TestBinder(t *testing.T) {
 
 			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
-			err = json.NewDecoder(resp.Body).Decode(&result)
+			err = Json.NewDecoder(resp.Body).Decode(&result)
 			require.NoError(t, err)
 			resp.Body.Close()
 			require.Len(t, result.Errors, 2)
@@ -178,7 +179,7 @@ func TestBinder(t *testing.T) {
 
 			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
-			err = json.NewDecoder(resp.Body).Decode(&result)
+			err = Json.NewDecoder(resp.Body).Decode(&result)
 			require.NoError(t, err)
 			resp.Body.Close()
 			require.Len(t, result.Errors, 2)

--- a/ext/htmx/htmx.go
+++ b/ext/htmx/htmx.go
@@ -81,8 +81,11 @@ func WriteHeader(c *xun.Context, key string, value any) {
 		return
 	}
 
-	buf, _ := Json.Marshal(value)
-	c.WriteHeader(key, string(buf))
+	buf := bytes.NewBuffer(nil)
+
+	Json.NewEncoder(buf).Encode(value) // nolint: errcheck
+
+	c.WriteHeader(key, buf.String())
 }
 
 //go:embed htmx.js

--- a/ext/htmx/htmx.go
+++ b/ext/htmx/htmx.go
@@ -64,7 +64,7 @@ const (
 )
 
 var (
-	json = xun.Json
+	Json = xun.Json
 )
 
 // HxHeader represents a map of string keys to values of any type.
@@ -81,7 +81,7 @@ func WriteHeader(c *xun.Context, key string, value any) {
 		return
 	}
 
-	buf, _ := json.Marshal(value)
+	buf, _ := Json.Marshal(value)
 	c.WriteHeader(key, string(buf))
 }
 

--- a/ext/htmx/htmx.go
+++ b/ext/htmx/htmx.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/yaitoo/xun"
 )
 
@@ -65,7 +64,7 @@ const (
 )
 
 var (
-	json = jsoniter.Config{UseNumber: false}.Froze()
+	json = xun.Json
 )
 
 // HxHeader represents a map of string keys to values of any type.

--- a/ext/htmx/htmx_test.go
+++ b/ext/htmx/htmx_test.go
@@ -2,6 +2,7 @@ package htmx
 
 import (
 	"bytes"
+	"encoding/json"
 	"html/template"
 	"io"
 	"net/http"

--- a/ext/htmx/interceptor_test.go
+++ b/ext/htmx/interceptor_test.go
@@ -62,7 +62,7 @@ func TestHtmxInterceptor(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	err = json.NewDecoder(resp.Body).Decode(&referer)
+	err = Json.NewDecoder(resp.Body).Decode(&referer)
 	require.NoError(t, err)
 
 	require.Equal(t, "/home", referer)
@@ -76,7 +76,7 @@ func TestHtmxInterceptor(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	err = json.NewDecoder(resp.Body).Decode(&referer)
+	err = Json.NewDecoder(resp.Body).Decode(&referer)
 	require.NoError(t, err)
 
 	require.Equal(t, "/home", referer)
@@ -89,7 +89,7 @@ func TestHtmxInterceptor(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	err = json.NewDecoder(resp.Body).Decode(&referer)
+	err = Json.NewDecoder(resp.Body).Decode(&referer)
 	require.NoError(t, err)
 
 	require.Empty(t, referer) // empty referer
@@ -103,7 +103,7 @@ func TestHtmxInterceptor(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	err = json.NewDecoder(resp.Body).Decode(&referer)
+	err = Json.NewDecoder(resp.Body).Decode(&referer)
 	require.NoError(t, err)
 
 	require.Empty(t, referer)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.25.0
-	github.com/json-iterator/go v1.1.12
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.33.0
 )
@@ -16,8 +15,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
@@ -15,21 +13,10 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.25.0 h1:5Dh7cjvzR7BRZadnsVOzPhWsrwUr0nmsZJxEAnFLNO8=
 github.com/go-playground/validator/v10 v10.25.0/go.mod h1:GGzBIJMuE98Ic/kJsBXbz1x/7cByt++cQ+YOuDM5wus=
-github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
-github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
-github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
-github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=

--- a/json.go
+++ b/json.go
@@ -1,0 +1,58 @@
+package xun
+
+import (
+	"encoding/json"
+	"io"
+)
+
+var Json JsonEncoding
+
+func init() {
+	Json = &stdJsonEncoding{}
+}
+
+// JsonEncoding is the interface that defines the methods that the standard
+// library encoding/json package provides.
+type JsonEncoding interface {
+	Marshal(v interface{}) ([]byte, error)
+	MarshalIndent(v interface{}, prefix, indent string) ([]byte, error)
+	UnmarshalFromString(str string, v interface{}) error
+	Unmarshal(data []byte, v interface{}) error
+	NewEncoder(writer io.Writer) Encoder
+	NewDecoder(reader io.Reader) Decoder
+}
+
+type Decoder interface {
+	Decode(obj interface{}) error
+}
+
+type Encoder interface {
+	Encode(val interface{}) error
+}
+
+type stdJsonEncoding struct {
+}
+
+func (e *stdJsonEncoding) Marshal(v interface{}) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+func (e *stdJsonEncoding) MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {
+	return json.MarshalIndent(v, prefix, indent)
+}
+
+func (e *stdJsonEncoding) UnmarshalFromString(str string, v interface{}) error {
+	return json.Unmarshal([]byte(str), v)
+}
+
+func (e *stdJsonEncoding) Unmarshal(data []byte, v interface{}) error {
+	return json.Unmarshal(data, v)
+}
+
+func (e *stdJsonEncoding) NewEncoder(writer io.Writer) Encoder {
+	return json.NewEncoder(writer)
+}
+
+func (e *stdJsonEncoding) NewDecoder(reader io.Reader) Decoder {
+	return json.NewDecoder(reader)
+}

--- a/json.go
+++ b/json.go
@@ -5,19 +5,11 @@ import (
 	"io"
 )
 
-var Json JsonEncoding
-
-func init() {
-	Json = &stdJsonEncoding{}
-}
+var Json JsonEncoding = &stdJsonEncoding{}
 
 // JsonEncoding is the interface that defines the methods that the standard
 // library encoding/json package provides.
 type JsonEncoding interface {
-	Marshal(v interface{}) ([]byte, error)
-	MarshalIndent(v interface{}, prefix, indent string) ([]byte, error)
-	UnmarshalFromString(str string, v interface{}) error
-	Unmarshal(data []byte, v interface{}) error
 	NewEncoder(writer io.Writer) Encoder
 	NewDecoder(reader io.Reader) Decoder
 }
@@ -31,22 +23,6 @@ type Encoder interface {
 }
 
 type stdJsonEncoding struct {
-}
-
-func (*stdJsonEncoding) Marshal(v interface{}) ([]byte, error) {
-	return json.Marshal(v)
-}
-
-func (*stdJsonEncoding) MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {
-	return json.MarshalIndent(v, prefix, indent)
-}
-
-func (*stdJsonEncoding) UnmarshalFromString(str string, v interface{}) error {
-	return json.Unmarshal([]byte(str), v)
-}
-
-func (*stdJsonEncoding) Unmarshal(data []byte, v interface{}) error {
-	return json.Unmarshal(data, v)
 }
 
 func (*stdJsonEncoding) NewEncoder(writer io.Writer) Encoder {

--- a/json.go
+++ b/json.go
@@ -33,26 +33,26 @@ type Encoder interface {
 type stdJsonEncoding struct {
 }
 
-func (e *stdJsonEncoding) Marshal(v interface{}) ([]byte, error) {
+func (*stdJsonEncoding) Marshal(v interface{}) ([]byte, error) {
 	return json.Marshal(v)
 }
 
-func (e *stdJsonEncoding) MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {
+func (*stdJsonEncoding) MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {
 	return json.MarshalIndent(v, prefix, indent)
 }
 
-func (e *stdJsonEncoding) UnmarshalFromString(str string, v interface{}) error {
+func (*stdJsonEncoding) UnmarshalFromString(str string, v interface{}) error {
 	return json.Unmarshal([]byte(str), v)
 }
 
-func (e *stdJsonEncoding) Unmarshal(data []byte, v interface{}) error {
+func (*stdJsonEncoding) Unmarshal(data []byte, v interface{}) error {
 	return json.Unmarshal(data, v)
 }
 
-func (e *stdJsonEncoding) NewEncoder(writer io.Writer) Encoder {
+func (*stdJsonEncoding) NewEncoder(writer io.Writer) Encoder {
 	return json.NewEncoder(writer)
 }
 
-func (e *stdJsonEncoding) NewDecoder(reader io.Reader) Decoder {
+func (*stdJsonEncoding) NewDecoder(reader io.Reader) Decoder {
 	return json.NewDecoder(reader)
 }

--- a/routing_option_test.go
+++ b/routing_option_test.go
@@ -1,6 +1,7 @@
 package xun
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"io"
 	"net/http"
@@ -93,7 +94,7 @@ func TestRoutingOption(t *testing.T) {
 	resp.Body.Close()
 
 	d1 := make(map[string]any)
-	err = Json.Unmarshal(buf, &d1)
+	err = json.Unmarshal(buf, &d1)
 	require.NoError(t, err)
 
 	require.Equal(t, "v1", d1["s1"])
@@ -112,7 +113,7 @@ func TestRoutingOption(t *testing.T) {
 	resp.Body.Close()
 
 	d2 := make(map[string]any)
-	err = Json.Unmarshal(buf, &d2)
+	err = json.Unmarshal(buf, &d2)
 	require.NoError(t, err)
 
 	require.Equal(t, "", d2["s1"])
@@ -131,7 +132,7 @@ func TestRoutingOption(t *testing.T) {
 	resp.Body.Close()
 
 	d3 := make(map[string]any)
-	err = Json.Unmarshal(buf, &d3)
+	err = json.Unmarshal(buf, &d3)
 	require.NoError(t, err)
 
 	require.Equal(t, "", d3["s1"])

--- a/routing_option_test.go
+++ b/routing_option_test.go
@@ -93,7 +93,7 @@ func TestRoutingOption(t *testing.T) {
 	resp.Body.Close()
 
 	d1 := make(map[string]any)
-	err = json.Unmarshal(buf, &d1)
+	err = Json.Unmarshal(buf, &d1)
 	require.NoError(t, err)
 
 	require.Equal(t, "v1", d1["s1"])
@@ -112,7 +112,7 @@ func TestRoutingOption(t *testing.T) {
 	resp.Body.Close()
 
 	d2 := make(map[string]any)
-	err = json.Unmarshal(buf, &d2)
+	err = Json.Unmarshal(buf, &d2)
 	require.NoError(t, err)
 
 	require.Equal(t, "", d2["s1"])
@@ -131,7 +131,7 @@ func TestRoutingOption(t *testing.T) {
 	resp.Body.Close()
 
 	d3 := make(map[string]any)
-	err = json.Unmarshal(buf, &d3)
+	err = Json.Unmarshal(buf, &d3)
 	require.NoError(t, err)
 
 	require.Equal(t, "", d3["s1"])

--- a/viewengine_text_test.go
+++ b/viewengine_text_test.go
@@ -112,7 +112,7 @@ func TestWatchOnText(t *testing.T) {
 	require.NoError(t, err)
 
 	var content string
-	err = json.NewDecoder(resp.Body).Decode(&content)
+	err = Json.NewDecoder(resp.Body).Decode(&content)
 	require.NoError(t, err)
 	require.Empty(t, content)
 	resp.Body.Close()

--- a/viewer_json.go
+++ b/viewer_json.go
@@ -29,7 +29,7 @@ func (*JsonViewer) Render(ctx *Context, data any) error { // skipcq: RVV-B0012
 		buf := BufPool.Get()
 		defer BufPool.Put(buf)
 
-		err = json.NewEncoder(buf).Encode(data)
+		err = Json.NewEncoder(buf).Encode(data)
 		if err != nil {
 			return err
 		}

--- a/viewer_json_test.go
+++ b/viewer_json_test.go
@@ -25,7 +25,7 @@ func TestJsonViewerRenderError(t *testing.T) {
 	// should get raw error when json.marshal fails, and StatusCode should be written
 	err := v.Render(ctx, data)
 	require.Error(t, err)
-	require.Equal(t, "chan int is unsupported type", err.Error())
+	require.Equal(t, "json: unsupported type: chan int", err.Error())
 
 	require.Equal(t, -1, rw.Code)
 


### PR DESCRIPTION
### Changed
-

### Fixed
- fix(json): use std json instead of json-iterator to support omitzero

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

This pull request replaces the `json-iterator` library with the standard `encoding/json` package to enable the `omitempty` option for JSON serialization. It also updates the code to use the standard `encoding/json` package and removes the `json-iterator` dependency.

Bug Fixes:
- Replaces the `json-iterator` library with the standard `encoding/json` package to enable the `omitempty` option for JSON serialization.

Enhancements:
- Updates the code to use the standard `encoding/json` package instead of `json-iterator`.

Chores:
- Removes the `json-iterator` dependency.