### PR TITLE
feat(acl): added `Whitelist` to allowing specific paths to bypass host checking

### DIFF
--- a/ext/acl/acl.go
+++ b/ext/acl/acl.go
@@ -45,6 +45,15 @@ func New(opts ...Option) xun.Middleware {
 			if len(o.AllowHosts) > 0 {
 				_, allow := o.AllowHosts[m.Host]
 				if !allow {
+					for _, it := range o.HostRedirectWhitelist {
+						if strings.EqualFold(c.Request.URL.Path, it) {
+							allow = true
+							break
+						}
+					}
+				}
+
+				if !allow {
 					if o.HostRedirectStatusCode > 0 && o.HostRedirectURL != "" {
 						return redirect(c, o)
 					}

--- a/ext/acl/acl.go
+++ b/ext/acl/acl.go
@@ -1,3 +1,10 @@
+// This package provides Access Control List (ACL) middleware for the Xun framework.
+// It allows for configuring allowed and denied hosts, IP networks, and countries
+// based on configuration files. The middleware supports dynamic reloading of rules
+// when the configuration file changes, enabling real-time updates to access rules.
+// It also offers functionality for host redirection and integrates with the Xun
+// framework's context to apply these rules to incoming requests.
+
 package acl
 
 import (
@@ -14,7 +21,9 @@ var (
 	v      atomic.Value
 )
 
-func New(opts ...Option) xun.Middleware {
+// New returns a new ACL middleware that applies access rules based on the provided options.
+// It dynamically reloads rules if a configuration file is specified, enabling real-time updates.
+func New(opts ...Option) xun.Middleware { // skipcq: GO-R1005
 	options := NewOptions()
 
 	for _, opt := range opts {

--- a/ext/acl/acl.go
+++ b/ext/acl/acl.go
@@ -45,7 +45,7 @@ func New(opts ...Option) xun.Middleware {
 			if len(o.AllowHosts) > 0 {
 				_, allow := o.AllowHosts[m.Host]
 				if !allow {
-					for _, it := range o.HostRedirectWhitelist {
+					for _, it := range o.HostWhitelist {
 						if strings.EqualFold(c.Request.URL.Path, it) {
 							allow = true
 							break

--- a/ext/acl/config.go
+++ b/ext/acl/config.go
@@ -27,7 +27,7 @@ var openFile = func(file string) (fs.File, error) {
 	return os.OpenFile(file, os.O_RDONLY, 0600)
 }
 
-func loadOptions(file string, o *Options) bool {
+func loadOptions(file string, o *Options) bool { // skipcq: GO-R1005
 	f, err := openFile(file)
 	if err != nil {
 		Logger.Println("acl: can't read file", file, err)

--- a/ext/acl/config.go
+++ b/ext/acl/config.go
@@ -19,6 +19,7 @@ const (
 	SectionDN                // deny_ipnets
 	SectionAC                // allow_countries
 	SectionDC                // deny_countries
+	SectionWL                // host_whitelist
 )
 
 var openFile = func(file string) (fs.File, error) {
@@ -65,6 +66,9 @@ func loadOptions(file string, o *Options) bool {
 		case "[deny_countries]":
 			section = SectionDC
 			continue
+		case "[host_whitelist]":
+			section = SectionWL
+			continue
 		}
 
 		switch section {
@@ -78,6 +82,8 @@ func loadOptions(file string, o *Options) bool {
 			AllowCountries(l)(o)
 		case SectionDC:
 			DenyCountries(l)(o)
+		case SectionWL:
+			WithHostWhitelist(l)(o)
 		}
 
 	}

--- a/ext/acl/config_test.go
+++ b/ext/acl/config_test.go
@@ -20,9 +20,15 @@ func TestConfig(t *testing.T) {
 			Data: []byte(`
 [allow_hosts]
 abc.com
+
+[host_whitelist]
+/allow
+/admin
+
 [host_redirect]
 url=http://abc.com
 status_code=301
+
 [allow_ipnets]
 172.0.0.0/24
 192.0.0.1
@@ -72,6 +78,7 @@ us
 		require.Len(t, o.AllowHosts, 0)
 		require.Empty(t, o.HostRedirectURL)
 		require.Equal(t, 302, o.HostRedirectStatusCode)
+		require.Len(t, o.HostWhitelist, 0)
 
 		require.Len(t, o.AllowIPNets, 0)
 		require.Len(t, o.DenyIPNets, 0)
@@ -94,6 +101,9 @@ us
 		require.Len(t, o.AllowHosts, 1)
 		require.Equal(t, "http://abc.com", o.HostRedirectURL)
 		require.Equal(t, 301, o.HostRedirectStatusCode)
+		require.Len(t, o.HostWhitelist, 2)
+		require.Equal(t, "/allow", o.HostWhitelist[0])
+		require.Equal(t, "/admin", o.HostWhitelist[1])
 
 		require.Len(t, o.AllowIPNets, 2)
 		require.Equal(t, ParseIPNet("172.0.0.0/24"), o.AllowIPNets[0])
@@ -128,6 +138,9 @@ cn
 [host_redirect]
 url=http://123.com
 status_code=302
+
+[host_whitelist]
+/status
 `)
 
 	mu.Lock()
@@ -144,6 +157,8 @@ status_code=302
 		require.Len(t, o.AllowHosts, 1)
 		require.Equal(t, "http://123.com", o.HostRedirectURL)
 		require.Equal(t, 302, o.HostRedirectStatusCode)
+		require.Len(t, o.HostWhitelist, 1)
+		require.Equal(t, "/status", o.HostWhitelist[0])
 
 		require.Len(t, o.AllowIPNets, 0)
 

--- a/ext/acl/option.go
+++ b/ext/acl/option.go
@@ -20,6 +20,7 @@ type Options struct {
 
 	HostRedirectURL        string
 	HostRedirectStatusCode int
+	HostRedirectWhitelist  []string
 
 	AllowIPNets []*net.IPNet
 	DenyIPNets  []*net.IPNet
@@ -144,12 +145,13 @@ func WithConfig(file string) Option {
 
 // WithHostRedirect sets the redirect URL and status code for host redirection.
 // It configures the Options to redirect requests to the specified URL with the given status code.
-func WithHostRedirect(u string, code int) Option {
+func WithHostRedirect(u string, code int, whitelist ...string) Option {
 	return func(o *Options) {
 		u, err := url.Parse(u)
 		if err == nil {
 			o.HostRedirectURL = u.String()
 			o.HostRedirectStatusCode = code
+			o.HostRedirectWhitelist = whitelist
 		}
 	}
 }

--- a/ext/acl/option.go
+++ b/ext/acl/option.go
@@ -155,10 +155,10 @@ func WithHostRedirect(u string, code int) Option {
 	}
 }
 
-// WithHostWhitelist sets the whitelist for host redirection.
-func WithHostWhitelist(whitelist ...string) Option {
+// WithHostWhitelist sets the whitelist for AllowHosts,allowing specific paths to bypass host checking.
+func WithHostWhitelist(paths ...string) Option {
 	return func(o *Options) {
-		o.HostWhitelist = append(o.HostWhitelist, whitelist...)
+		o.HostWhitelist = append(o.HostWhitelist, paths...)
 	}
 }
 

--- a/ext/acl/option.go
+++ b/ext/acl/option.go
@@ -20,7 +20,7 @@ type Options struct {
 
 	HostRedirectURL        string
 	HostRedirectStatusCode int
-	HostRedirectWhitelist  []string
+	HostWhitelist          []string
 
 	AllowIPNets []*net.IPNet
 	DenyIPNets  []*net.IPNet
@@ -145,14 +145,20 @@ func WithConfig(file string) Option {
 
 // WithHostRedirect sets the redirect URL and status code for host redirection.
 // It configures the Options to redirect requests to the specified URL with the given status code.
-func WithHostRedirect(u string, code int, whitelist ...string) Option {
+func WithHostRedirect(u string, code int) Option {
 	return func(o *Options) {
 		u, err := url.Parse(u)
 		if err == nil {
 			o.HostRedirectURL = u.String()
 			o.HostRedirectStatusCode = code
-			o.HostRedirectWhitelist = whitelist
 		}
+	}
+}
+
+// WithHostWhitelist sets the whitelist for host redirection.
+func WithHostWhitelist(whitelist ...string) Option {
+	return func(o *Options) {
+		o.HostWhitelist = append(o.HostWhitelist, whitelist...)
 	}
 }
 


### PR DESCRIPTION
### Changed
-

### Fixed
- 

### Added
- feat(acl): added `Whitelist` to ignore paths in `AllowHosts` checking

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Adds a whitelist feature to the `AllowHosts` middleware, enabling the exclusion of specific paths from host checking. This allows certain URLs to bypass the `AllowHosts` restriction, providing more flexibility in access control.

New Features:
- Introduces a whitelist to the `AllowHosts` middleware, allowing specific paths to bypass host checking.

Enhancements:
- Adds the ability to configure a host whitelist via code and configuration files.