### PR TITLE
fix(htmx): added `fetch` wrapper to support `Hx-Trigger` feature like htmx request

### DIFF
--- a/README.md
+++ b/README.md
@@ -993,9 +993,9 @@ The library to enable seamless integration between native JavaScript methods and
 #### 5. Setup Hx-Trigger listener
 > app.js
 ```js
-xun.ready(function(evt) {
+$x.ready(function(evt) {
 	document.addEventListener("showMessage", function(evt){
-    alert(evt.detail.value);
+    alert(evt.detail);
   })
 },'body');
 

--- a/ext/htmx/htmx.js
+++ b/ext/htmx/htmx.js
@@ -1,37 +1,65 @@
-window.xun = window.xun || {
-  /**
-   * A global object to manage custom events and callbacks.
-   *
-   * @property {Function} ready - Registers a callback function to be executed once when 
-   * the DOM is fully loaded or when an `htmx:load` event occurs.
-   * 
-   * @function ready
-   * @param {Function} callback - The callback function to be executed.
-   * @param {String} selector - The selector to be used to check if the callback should be executed.
-   */
-    ready:function(callback,selector){
-      const f = function(evt){
-       if(selector){
-        if(document.querySelector(selector)){
+(function(){
+  window.$x = window.$x || {
+    /**
+     * A global object to manage custom events and callbacks.
+     *
+     * @property {Function} ready - Registers a callback function to be executed once when 
+     * the DOM is fully loaded or when an `htmx:load` event occurs.
+     * 
+     * @function ready
+     * @param {Function} callback - The callback function to be executed.
+     * @param {String} selector - The selector to be used to check if the callback should be executed.
+     */
+      ready:function(callback,selector){
+        const f = function(evt){
+         if(selector){
+          if(document.querySelector(selector)){
+            callback(evt);
+          }
+         }else{
           callback(evt);
+         }
         }
-       }else{
-        callback(evt);
-       }
-      }
-      let boosted = false;
-      document.addEventListener('DOMContentLoaded',function(evt){
-        f(evt);
-      });
-      document.addEventListener('htmx:load', function(evt) {
-        if(boosted){
+        let boosted = false;
+        document.addEventListener('DOMContentLoaded',function(evt){
           f(evt);
-          boosted = false;  
+        });
+        document.addEventListener('htmx:load', function(evt) {
+          if(boosted){
+            f(evt);
+            boosted = false;  
+          }
+        });  
+        document.addEventListener('htmx:beforeOnLoad', function(evt) {
+          // trigger ready function again when a boosted request is done
+          boosted = evt.detail.boosted;
+        });
+      },
+      /**
+       * The fetch function is a wrapper of native fetch with Hx-Trigger support like it in htmx requests.
+       * 
+       * @function fetch
+       * @async
+       * @param {String|Request} input - The URL to be requested or the Request object.
+       * @param {Object} init - The options to be used for the request. See the 
+       * {@link https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch|fetch} API.
+       * @returns {Promise<Response>} - The response of the request.
+       */
+      fetch : async (...args) => {
+        const response = await fetch(...args);
+        if (!response.ok){
+            const hx = response.headers.get("Hx-Trigger");
+            if(hx){
+                const d = JSON.parse(hx)
+                const keys = Object.keys(d);
+                for (const key of keys) {
+                    window.dispatchEvent(new CustomEvent(key, {detail: d[key]}));
+                }
+            }
         }
-      });  
-      document.addEventListener('htmx:beforeOnLoad', function(evt) {
-        // trigger ready function again when a boosted request is done
-        boosted = evt.detail.boosted;
-      });
+        return response;
+      },
     }
-  }
+})
+
+

--- a/ext/htmx/htmx.js
+++ b/ext/htmx/htmx.js
@@ -55,10 +55,14 @@
       if (!response.ok) {
         const hx = response.headers.get("Hx-Trigger");
         if (hx) {
-          const d = JSON.parse(hx);
-          const keys = Object.keys(d);
-          for (const key of keys) {
-            window.dispatchEvent(new CustomEvent(key, { detail: d[key] }));
+          try{
+            const d = JSON.parse(hx);
+            const keys = Object.keys(d);
+            for (const key of keys) {
+              window.dispatchEvent(new CustomEvent(key, { detail: d[key] }));
+            }
+          }catch(e){ 
+            // prevent invalid JSON from breaking the application
           }
         }
       }

--- a/ext/htmx/htmx.js
+++ b/ext/htmx/htmx.js
@@ -1,65 +1,68 @@
-(function(){
+(function () {
   window.$x = window.$x || {
     /**
      * A global object to manage custom events and callbacks.
      *
-     * @property {Function} ready - Registers a callback function to be executed once when 
-     * the DOM is fully loaded or when an `htmx:load` event occurs.
-     * 
+     * @property {Function} ready - Registers a callback function to be executed
+     * once when the DOM is fully loaded or when an `htmx:load` event occurs.
+     *
      * @function ready
      * @param {Function} callback - The callback function to be executed.
-     * @param {String} selector - The selector to be used to check if the callback should be executed.
+     * @param {String} selector - The selector to be used to check if the callback
+     *     should be executed.
      */
-      ready:function(callback,selector){
-        const f = function(evt){
-         if(selector){
-          if(document.querySelector(selector)){
+    ready: function (callback, selector) {
+      const f = function (evt) {
+        if (selector) {
+          if (document.querySelector(selector)) {
             callback(evt);
           }
-         }else{
+        } else {
           callback(evt);
-         }
         }
-        let boosted = false;
-        document.addEventListener('DOMContentLoaded',function(evt){
+      };
+      let boosted = false;
+      document.addEventListener("DOMContentLoaded", function (evt) {
+        f(evt);
+      });
+      document.addEventListener("htmx:load", function (evt) {
+        if (boosted) {
           f(evt);
-        });
-        document.addEventListener('htmx:load', function(evt) {
-          if(boosted){
-            f(evt);
-            boosted = false;  
-          }
-        });  
-        document.addEventListener('htmx:beforeOnLoad', function(evt) {
-          // trigger ready function again when a boosted request is done
-          boosted = evt.detail.boosted;
-        });
-      },
-      /**
-       * The fetch function is a wrapper of native fetch with Hx-Trigger support like it in htmx requests.
-       * 
-       * @function fetch
-       * @async
-       * @param {String|Request} input - The URL to be requested or the Request object.
-       * @param {Object} init - The options to be used for the request. See the 
-       * {@link https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch|fetch} API.
-       * @returns {Promise<Response>} - The response of the request.
-       */
-      fetch : async (...args) => {
-        const response = await fetch(...args);
-        if (!response.ok){
-            const hx = response.headers.get("Hx-Trigger");
-            if(hx){
-                const d = JSON.parse(hx)
-                const keys = Object.keys(d);
-                for (const key of keys) {
-                    window.dispatchEvent(new CustomEvent(key, {detail: d[key]}));
-                }
-            }
+          boosted = false;
         }
-        return response;
-      },
-    }
-})
-
-
+      });
+      document.addEventListener("htmx:beforeOnLoad", function (evt) {
+        // trigger ready function again when a boosted request is done
+        boosted = evt.detail.boosted;
+      });
+    },
+    /**
+     * The fetch function is a wrapper of native fetch with Hx-Trigger support
+     * like it in htmx requests.
+     *
+     * @function fetch
+     * @async
+     * @param {String|Request} input - The URL to be requested or the Request
+     *     object.
+     * @param {Object} init - The options to be used for the request. See the
+     * {@link
+     * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch|fetch}
+     * API.
+     * @returns {Promise<Response>} - The response of the request.
+     */
+    fetch: async (...args) => {
+      const response = await fetch(...args);
+      if (!response.ok) {
+        const hx = response.headers.get("Hx-Trigger");
+        if (hx) {
+          const d = JSON.parse(hx);
+          const keys = Object.keys(d);
+          for (const key of keys) {
+            window.dispatchEvent(new CustomEvent(key, { detail: d[key] }));
+          }
+        }
+      }
+      return response;
+    },
+  };
+})();


### PR DESCRIPTION
### Changed
-

### Fixed
-

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-test` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

This pull request introduces a `fetch` wrapper to support the `Hx-Trigger` feature, enabling server-sent events to trigger client-side actions like HTMX requests. It also renames the global object from `xun` to `$x`.

New Features:
- Adds a wrapper around the native `fetch` function to support the `Hx-Trigger` header, allowing server-sent events to trigger client-side actions similar to HTMX requests.

Enhancements:
- Updates the global object name from `xun` to `$x`.