### PR TITLE
fix(sse): fixed gzip/deflate compresser flush issue on SSE request

### DIFF
--- a/ext/sse/event.go
+++ b/ext/sse/event.go
@@ -1,8 +1,6 @@
 package sse
 
 import (
-	"bufio"
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -27,30 +25,24 @@ type TextEvent struct {
 // It outputs the event name and data in the SSE format, followed by two newlines.
 // Returns an error if the write operation fails.
 func (e *TextEvent) Write(w io.Writer) error {
-	_, err := fmt.Fprintf(w, "event: %s\n", e.Name)
-	if err != nil {
-		return err
+	// Write event header.
+	var b strings.Builder
+	b.WriteString("event: ")
+	b.WriteString(e.Name)
+	b.WriteString("\n")
+
+	// Split the data into lines.
+	lines := strings.Split(e.Data, "\n")
+	// Build the SSE response.
+	for _, line := range lines {
+		b.WriteString("data: ")
+		b.WriteString(line)
+		b.WriteString("\n")
 	}
+	b.WriteString("data:\n\n")
 
-	buf := &bytes.Buffer{}
-
-	scanner := bufio.NewScanner(strings.NewReader(e.Data))
-	scanner.Split(bufio.ScanLines)
-
-	for scanner.Scan() {
-		_, err = fmt.Fprintf(buf, "data: %s\n", scanner.Text())
-		if err != nil {
-			return err
-		}
-	}
-
-	_, err = fmt.Fprint(buf, "data:\n\n")
-	if err != nil {
-		return err
-	}
-
-	_, err = buf.WriteTo(w)
-
+	// Write the complete output.
+	_, err := io.WriteString(w, b.String())
 	return err
 }
 

--- a/ext/sse/server_test.go
+++ b/ext/sse/server_test.go
@@ -65,12 +65,12 @@ func TestServer(t *testing.T) {
 		err = c.Send(&TextEvent{Name: "event1", Data: "data1"})
 		require.NoError(t, err)
 		buf := rw.Body.Bytes()
-		require.Equal(t, "event: event1\ndata: data1\n\n", string(buf))
+		require.Equal(t, "event: event1\ndata: data1\ndata:\n\n", string(buf))
 
 		err = c.Send(&JsonEvent{Name: "event2", Data: "data2"})
 		require.NoError(t, err)
 		buf = rw.Body.Bytes()
-		require.Equal(t, "event: event1\ndata: data1\n\nevent: event2\ndata: \"data2\"\n\n", string(buf))
+		require.Equal(t, "event: event1\ndata: data1\ndata:\n\nevent: event2\ndata: \"data2\"\n\n", string(buf))
 	})
 
 	t.Run("broadcast", func(t *testing.T) {
@@ -95,7 +95,7 @@ func TestServer(t *testing.T) {
 		buf2 := rw2.Body.Bytes()
 
 		require.Equal(t, buf1, buf2)
-		require.Equal(t, "event: event1\ndata: data1\n\n", string(buf1))
+		require.Equal(t, "event: event1\ndata: data1\ndata:\n\n", string(buf1))
 
 		ctx, cancel := context.WithCancel(context.TODO())
 		cancel()

--- a/ext/sse/server_test.go
+++ b/ext/sse/server_test.go
@@ -1,8 +1,12 @@
 package sse
 
 import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/yaitoo/async"
+	"github.com/yaitoo/xun"
 )
 
 func TestServer(t *testing.T) {
@@ -149,6 +154,62 @@ func TestServer(t *testing.T) {
 		c2.Wait()
 
 		require.Len(t, srv.clients, 0)
+	})
+
+	t.Run("send_with_gzip", func(t *testing.T) {
+		srv := New()
+		rw := httptest.NewRecorder()
+
+		gc := &xun.GzipCompressor{}
+
+		c, err := srv.Join(context.TODO(), "send", gc.New(rw))
+		require.NoError(t, err)
+
+		err = c.Send(&TextEvent{Name: "event1", Data: "data1"})
+		require.NoError(t, err)
+
+		r, _ := gzip.NewReader(bytes.NewReader(rw.Body.Bytes()))
+
+		buf, _ := io.ReadAll(r)
+
+		require.Equal(t, "event: event1\ndata: data1\ndata:\n\n", string(buf))
+
+		err = c.Send(&JsonEvent{Name: "event2", Data: "data2"})
+		require.NoError(t, err)
+
+		r, _ = gzip.NewReader(bytes.NewReader(rw.Body.Bytes()))
+
+		buf, _ = io.ReadAll(r)
+
+		require.Equal(t, "event: event1\ndata: data1\ndata:\n\nevent: event2\ndata: \"data2\"\n\n", string(buf))
+	})
+
+	t.Run("send_with_deflate", func(t *testing.T) {
+		srv := New()
+		rw := httptest.NewRecorder()
+
+		gc := &xun.DeflateCompressor{}
+
+		c, err := srv.Join(context.TODO(), "send", gc.New(rw))
+		require.NoError(t, err)
+
+		err = c.Send(&TextEvent{Name: "event1", Data: "data1"})
+		require.NoError(t, err)
+
+		r := flate.NewReader(bytes.NewReader(rw.Body.Bytes()))
+
+		buf, _ := io.ReadAll(r)
+
+		require.Equal(t, "event: event1\ndata: data1\ndata:\n\n", string(buf))
+
+		err = c.Send(&JsonEvent{Name: "event2", Data: "data2"})
+		require.NoError(t, err)
+
+		r = flate.NewReader(bytes.NewReader(rw.Body.Bytes()))
+
+		buf, _ = io.ReadAll(r)
+
+		require.Equal(t, "event: event1\ndata: data1\ndata:\n\nevent: event2\ndata: \"data2\"\n\n", string(buf))
 	})
 }
 

--- a/response_writer_deflate.go
+++ b/response_writer_deflate.go
@@ -25,6 +25,13 @@ func (rw *deflateResponseWriter) Close() {
 	rw.w.Close()
 }
 
+// Flush writes any buffered data to the underlying writer and ensures that
+// the response is sent to the client. It locks the response writer to
+// prevent concurrent writes, flushes the compressed data, and then
+// flushes the standard response writer.
 func (rw *deflateResponseWriter) Flush() {
+	rw.mu.Lock()
+	defer rw.mu.Unlock()
 	rw.w.Flush()
+	rw.stdResponseWriter.Flush()
 }

--- a/response_writer_deflate.go
+++ b/response_writer_deflate.go
@@ -30,8 +30,6 @@ func (rw *deflateResponseWriter) Close() {
 // prevent concurrent writes, flushes the compressed data, and then
 // flushes the standard response writer.
 func (rw *deflateResponseWriter) Flush() {
-	rw.mu.Lock()
-	defer rw.mu.Unlock()
 	rw.w.Flush()
 	rw.stdResponseWriter.Flush()
 }

--- a/response_writer_deflate.go
+++ b/response_writer_deflate.go
@@ -24,3 +24,7 @@ func (rw *deflateResponseWriter) Write(p []byte) (int, error) {
 func (rw *deflateResponseWriter) Close() {
 	rw.w.Close()
 }
+
+func (rw *deflateResponseWriter) Flush() {
+	rw.w.Flush()
+}

--- a/response_writer_deflate_test.go
+++ b/response_writer_deflate_test.go
@@ -1,0 +1,45 @@
+package xun
+
+import (
+	"bytes"
+	"compress/flate"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeflateResponseWriter(t *testing.T) {
+	t.Run("flush", func(t *testing.T) {
+
+		rw := httptest.NewRecorder()
+
+		w, _ := flate.NewWriter(rw, flate.DefaultCompression) //nolint: errcheck because flate.DefaultCompression is a valid compression level
+
+		dw := &deflateResponseWriter{
+			w: w,
+			stdResponseWriter: &stdResponseWriter{
+				ResponseWriter: rw,
+			},
+		}
+
+		_, err := w.Write([]byte("chunk1"))
+		require.NoError(t, err)
+
+		r := flate.NewReader(bytes.NewReader(rw.Body.Bytes()))
+
+		buf, _ := io.ReadAll(r)
+
+		require.Len(t, buf, 0)
+
+		dw.Flush()
+
+		r = flate.NewReader(bytes.NewReader(rw.Body.Bytes()))
+
+		buf, _ = io.ReadAll(r)
+
+		require.Equal(t, "chunk1", string(buf))
+
+	})
+}

--- a/response_writer_gzip.go
+++ b/response_writer_gzip.go
@@ -2,18 +2,28 @@ package xun
 
 import (
 	"compress/gzip"
+	"net/http"
+	"sync"
 )
 
 // gzipResponseWriter is a custom http.ResponseWriter that wraps the standard
 // ResponseWriter and compresses the response using gzip.
 type gzipResponseWriter struct {
+	mu sync.Mutex
 	*stdResponseWriter
 	w *gzip.Writer
+}
+
+func (rw *gzipResponseWriter) Header() http.Header {
+	return rw.stdResponseWriter.ResponseWriter.Header()
 }
 
 // Write writes the data to the underlying gzip writer.
 // It implements the io.Writer interface.
 func (rw *gzipResponseWriter) Write(p []byte) (int, error) {
+	rw.mu.Lock()
+	defer rw.mu.Unlock()
+
 	n, err := rw.w.Write(p)
 	rw.bodySentBytes += n
 	return n, err
@@ -22,4 +32,11 @@ func (rw *gzipResponseWriter) Write(p []byte) (int, error) {
 // Close closes the gzipResponseWriter, ensuring that the underlying writer is also closed.
 func (rw *gzipResponseWriter) Close() {
 	rw.w.Close()
+}
+
+func (rw *gzipResponseWriter) Flush() {
+	rw.mu.Lock()
+	defer rw.mu.Unlock()
+	rw.w.Flush()
+	rw.stdResponseWriter.Flush()
 }

--- a/response_writer_gzip_test.go
+++ b/response_writer_gzip_test.go
@@ -1,0 +1,45 @@
+package xun
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGzipResponseWriter(t *testing.T) {
+	t.Run("flush", func(t *testing.T) {
+
+		rw := httptest.NewRecorder()
+
+		w := gzip.NewWriter(rw)
+
+		dw := &gzipResponseWriter{
+			w: w,
+			stdResponseWriter: &stdResponseWriter{
+				ResponseWriter: rw,
+			},
+		}
+
+		_, err := w.Write([]byte("chunk1"))
+		require.NoError(t, err)
+
+		r, _ := gzip.NewReader(bytes.NewReader(rw.Body.Bytes()))
+
+		buf, _ := io.ReadAll(r)
+
+		require.Len(t, buf, 0)
+
+		dw.Flush()
+
+		r, _ = gzip.NewReader(bytes.NewReader(rw.Body.Bytes()))
+
+		buf, _ = io.ReadAll(r)
+
+		require.Equal(t, "chunk1", string(buf))
+
+	})
+}

--- a/response_writer_std.go
+++ b/response_writer_std.go
@@ -14,6 +14,10 @@ type stdResponseWriter struct {
 func (*stdResponseWriter) Close() {
 }
 
+func (rw *stdResponseWriter) Header() http.Header {
+	return rw.ResponseWriter.Header()
+}
+
 // WriteHeader sends an HTTP response header with the specified status code.
 // It ensures that the header is only written once by checking if the statusCode
 // has already been set. If the statusCode is zero, it updates the statusCode

--- a/response_writer_std.go
+++ b/response_writer_std.go
@@ -14,10 +14,6 @@ type stdResponseWriter struct {
 func (*stdResponseWriter) Close() {
 }
 
-func (rw *stdResponseWriter) Header() http.Header {
-	return rw.ResponseWriter.Header()
-}
-
 // WriteHeader sends an HTTP response header with the specified status code.
 // It ensures that the header is only written once by checking if the statusCode
 // has already been set. If the statusCode is zero, it updates the statusCode


### PR DESCRIPTION
### Changed
-

### Fixed
- fix(sse): fixed gzip/deflate compresser flush issue on SSE request

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-tests` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Fixes an issue with gzip/deflate compression when used with Server-Sent Events (SSE). The changes ensure that the compression buffers are properly flushed, preventing incomplete data from being sent to the client. Also, the SSE event data is now correctly formatted.

Bug Fixes:
- Fixes a gzip/deflate compression issue that caused incomplete data to be sent in SSE requests by ensuring compression buffers are properly flushed.
- Fixes the formatting of SSE event data to include a newline character after each data line.