### PR TITLE
fix(sse): use ReadCloser instead of Reader

### DIFF
--- a/ext/sse/reader.go
+++ b/ext/sse/reader.go
@@ -8,10 +8,10 @@ import (
 )
 
 type EventReader struct {
-	r io.Reader
+	r io.ReadCloser
 }
 
-func NewReader(r io.Reader) *EventReader {
+func NewReader(r io.ReadCloser) *EventReader {
 	return &EventReader{r: r}
 }
 
@@ -64,4 +64,8 @@ func (r *EventReader) Next() (TextEvent, error) {
 			}
 		}
 	}
+}
+
+func (r *EventReader) Close() {
+	r.r.Close()
 }


### PR DESCRIPTION
### Changed
-

### Fixed
- fix(sse): use `ReadCloser` instead of `Reader`

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-tests` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.