### PR TITLE
fix(sse): breakline and concurrent write issues

### DIFF
--- a/ext/sse/event.go
+++ b/ext/sse/event.go
@@ -75,7 +75,7 @@ func (e *TextEvent) Write(w io.Writer) error {
 		sb.WriteString("\n")
 	}
 
-	sb.WriteString("\n")
+	sb.WriteString("\n\n")
 
 	// Write the complete output.
 	_, err := io.WriteString(w, sb.String())
@@ -139,7 +139,7 @@ func (e *JsonEvent) Write(w io.Writer) error {
 		}
 	}
 
-	sb.WriteString("\n")
+	sb.WriteString("\n\n")
 
 	// Write the complete output.
 	_, err = io.WriteString(w, sb.String())
@@ -150,6 +150,6 @@ type PingEvent struct {
 }
 
 func (evt *PingEvent) Write(w io.Writer) error {
-	_, err := io.WriteString(w, ": ping\n\n")
+	_, err := io.WriteString(w, ": ping\n\n\n")
 	return err
 }

--- a/ext/sse/reader.go
+++ b/ext/sse/reader.go
@@ -24,8 +24,9 @@ func (r *EventReader) Next() (TextEvent, error) {
 		line string
 		err  error
 
-		evt   TextEvent
-		retry int
+		evt          TextEvent
+		retry        int
+		breakLineNum int
 	)
 
 	for {
@@ -44,7 +45,11 @@ func (r *EventReader) Next() (TextEvent, error) {
 		}
 
 		if line == "\n" {
-			return evt, nil
+			breakLineNum++
+			if breakLineNum > 1 {
+				return evt, nil
+			}
+			continue
 		}
 
 		if strings.HasPrefix(line, "id:") {


### PR DESCRIPTION
### Changed
-

### Fixed
- fix(sse): used two breaklines to split event data
- fix(sse): added mutex to prevent data race issue on `Send`

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-tests` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.