### PR TITLE
fix(viewengine): continue to load other files when one file fails

### DIFF
--- a/app.go
+++ b/app.go
@@ -79,10 +79,7 @@ func New(opts ...Option) *App {
 
 	if app.fsys != nil {
 		for _, ve := range app.engines {
-			err := ve.Load(app.fsys, app)
-			if err != nil {
-				app.logger.Error("xun: load views", slog.Any("err", err))
-			}
+			ve.Load(app.fsys, app)
 		}
 
 		if app.watch {

--- a/app_test.go
+++ b/app_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) { // skipcq: RVV-B0012
 			if strings.HasPrefix(addr, "abc.com") {
-				return net.Dial("tcp", net.JoinHostPort("127.0.0.1", strings.TrimPrefix(addr, "abc.com")))
+				return net.Dial("tcp", net.JoinHostPort("127.0.0.1", strings.TrimPrefix(addr, "abc.com:")))
 			}
 			return net.Dial("tcp", addr)
 		},

--- a/app_test.go
+++ b/app_test.go
@@ -25,14 +25,16 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	tr := http.DefaultTransport.(*http.Transport).Clone()
-	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) { // skipcq: RVV-B0012
-		if strings.HasPrefix(addr, "abc.com") {
-			return net.Dial("tcp", strings.TrimPrefix(addr, "abc.com"))
-		}
-		return net.Dial("tcp", addr)
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) { // skipcq: RVV-B0012
+			if strings.HasPrefix(addr, "abc.com") {
+				return net.Dial("tcp", "127.0.0.1"+strings.TrimPrefix(addr, "abc.com"))
+			}
+			return net.Dial("tcp", addr)
+		},
 	}
+
 	client = http.Client{
 		Transport: tr,
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) { // skipcq: RVV-B0012
 			if strings.HasPrefix(addr, "abc.com") {
-				return net.Dial("tcp", "127.0.0.1"+strings.TrimPrefix(addr, "abc.com"))
+				return net.Dial("tcp", net.JoinHostPort("127.0.0.1", strings.TrimPrefix(addr, "abc.com")))
 			}
 			return net.Dial("tcp", addr)
 		},

--- a/app_watch_test.go
+++ b/app_watch_test.go
@@ -286,8 +286,8 @@ func TestWatchOnHtml(t *testing.T) {
 type mockViewEngine struct {
 }
 
-func (*mockViewEngine) Load(fsys fs.FS, app *App) error { // skipcq: RVV-B0012
-	return nil
+func (*mockViewEngine) Load(fsys fs.FS, app *App) { // skipcq: RVV-B0012
+
 }
 func (*mockViewEngine) FileChanged(fsys fs.FS, app *App, event fsnotify.Event) error { // skipcq: RVV-B0012
 	return errors.New("err: unhandled error")

--- a/viewengine.go
+++ b/viewengine.go
@@ -10,6 +10,6 @@ import (
 // an effective view engine, namely methods for loading templates from a file
 // system and reloading templates when the file system changes.
 type ViewEngine interface {
-	Load(fsys fs.FS, app *App) error
+	Load(fsys fs.FS, app *App)
 	FileChanged(fsys fs.FS, app *App, event fsnotify.Event) error
 }

--- a/viewengine_html.go
+++ b/viewengine_html.go
@@ -114,7 +114,7 @@ func (ve *HtmlViewEngine) loadLayouts() {
 
 		if d != nil && !d.IsDir() {
 			if _, err := ve.loadTemplate(path); err != nil {
-				ve.app.logger.Error("html: load html layuots", slog.String("path", path), slog.Any("err", err))
+				ve.app.logger.Error("html: load html layouts", slog.String("path", path), slog.Any("err", err))
 			}
 		}
 

--- a/viewengine_html.go
+++ b/viewengine_html.go
@@ -77,7 +77,7 @@ func (ve *HtmlViewEngine) FileChanged(fsys fs.FS, app *App, event fsnotify.Event
 
 func (ve *HtmlViewEngine) loadComponents() {
 	fs.WalkDir(ve.fsys, "components", func(path string, d fs.DirEntry, _ error) error { // nolint: errcheck
-		if d == nil || d.IsDir() || !strings.EqualFold(filepath.Ext(path), ".html") {
+		if !strings.EqualFold(filepath.Ext(path), ".html") {
 			return nil
 		}
 
@@ -112,7 +112,7 @@ func (ve *HtmlViewEngine) loadTemplate(path string) (*HtmlTemplate, error) {
 func (ve *HtmlViewEngine) loadLayouts() {
 	fs.WalkDir(ve.fsys, "layouts", func(path string, d fs.DirEntry, _ error) error { // nolint: errcheck
 
-		if d != nil && !d.IsDir() {
+		if strings.EqualFold(filepath.Ext(path), ".html") {
 			if _, err := ve.loadTemplate(path); err != nil {
 				ve.app.logger.Error("html: load html layouts", slog.String("path", path), slog.Any("err", err))
 			}
@@ -125,7 +125,7 @@ func (ve *HtmlViewEngine) loadLayouts() {
 func (ve *HtmlViewEngine) loadPages() {
 	fs.WalkDir(ve.fsys, "pages", func(path string, d fs.DirEntry, _ error) error { // nolint: errcheck
 
-		if d == nil || d.IsDir() || !strings.EqualFold(filepath.Ext(path), ".html") {
+		if !strings.EqualFold(filepath.Ext(path), ".html") {
 			return nil
 		}
 
@@ -166,7 +166,7 @@ func (ve *HtmlViewEngine) loadPage(path string) error {
 func (ve *HtmlViewEngine) loadViews() {
 	fs.WalkDir(ve.fsys, "views", func(path string, d fs.DirEntry, _ error) error { // nolint: errcheck
 
-		if d == nil || d.IsDir() || !strings.EqualFold(filepath.Ext(path), ".html") {
+		if !strings.EqualFold(filepath.Ext(path), ".html") {
 			return nil
 		}
 

--- a/viewengine_html.go
+++ b/viewengine_html.go
@@ -1,8 +1,8 @@
 package xun
 
 import (
-	"errors"
 	"io/fs"
+	"log/slog"
 	"path/filepath"
 	"strings"
 
@@ -27,7 +27,7 @@ type HtmlViewEngine struct {
 // Load loads all templates from the given file system.
 //
 // It loads all components, layouts, pages and views from the given file system.
-func (ve *HtmlViewEngine) Load(fsys fs.FS, app *App) error {
+func (ve *HtmlViewEngine) Load(fsys fs.FS, app *App) {
 	if ve.templates == nil {
 		ve.templates = map[string]*HtmlTemplate{}
 	}
@@ -35,23 +35,10 @@ func (ve *HtmlViewEngine) Load(fsys fs.FS, app *App) error {
 	ve.fsys = fsys
 	ve.app = app
 
-	err := ve.loadComponents()
-	if err != nil {
-		return err
-	}
-
-	err = ve.loadLayouts()
-	if err != nil {
-		return err
-	}
-
-	err = ve.loadPages()
-	if err != nil {
-		return err
-	}
-
-	return ve.loadViews()
-
+	ve.loadComponents()
+	ve.loadLayouts()
+	ve.loadPages()
+	ve.loadViews()
 }
 
 // FileChanged is called when a file has been changed.
@@ -88,25 +75,17 @@ func (ve *HtmlViewEngine) FileChanged(fsys fs.FS, app *App, event fsnotify.Event
 
 }
 
-func (ve *HtmlViewEngine) loadComponents() error {
-	err := fs.WalkDir(ve.fsys, "components", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() || !strings.EqualFold(filepath.Ext(path), ".html") {
+func (ve *HtmlViewEngine) loadComponents() {
+	fs.WalkDir(ve.fsys, "components", func(path string, d fs.DirEntry, _ error) error { // nolint: errcheck
+		if d == nil || d.IsDir() || !strings.EqualFold(filepath.Ext(path), ".html") {
 			return nil
 		}
 
-		_, err = ve.loadTemplate(path)
-		return err
-	})
-
-	if err != nil && errors.Is(err, fs.ErrNotExist) {
+		if _, err := ve.loadTemplate(path); err != nil {
+			ve.app.logger.Error("xun: load html components", slog.String("path", path), slog.Any("err", err))
+		}
 		return nil
-	}
-
-	return err
-
+	})
 }
 
 func (ve *HtmlViewEngine) loadTemplate(path string) (*HtmlTemplate, error) {
@@ -130,49 +109,32 @@ func (ve *HtmlViewEngine) loadTemplate(path string) (*HtmlTemplate, error) {
 	return t, nil
 }
 
-func (ve *HtmlViewEngine) loadLayouts() error {
-	err := fs.WalkDir(ve.fsys, "layouts", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
+func (ve *HtmlViewEngine) loadLayouts() {
+	fs.WalkDir(ve.fsys, "layouts", func(path string, d fs.DirEntry, _ error) error { // nolint: errcheck
 
-		if !d.IsDir() {
-
-			_, err = ve.loadTemplate(path)
-
-			return err
-
+		if d != nil && !d.IsDir() {
+			if _, err := ve.loadTemplate(path); err != nil {
+				ve.app.logger.Error("html: load html layuots", slog.String("path", path), slog.Any("err", err))
+			}
 		}
 
 		return nil
 	})
-
-	if err != nil && errors.Is(err, fs.ErrNotExist) {
-		return nil
-	}
-
-	return err
 }
 
-func (ve *HtmlViewEngine) loadPages() error {
-	err := fs.WalkDir(ve.fsys, "pages", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
+func (ve *HtmlViewEngine) loadPages() {
+	fs.WalkDir(ve.fsys, "pages", func(path string, d fs.DirEntry, _ error) error { // nolint: errcheck
 
-		if d.IsDir() || !strings.EqualFold(filepath.Ext(path), ".html") {
+		if d == nil || d.IsDir() || !strings.EqualFold(filepath.Ext(path), ".html") {
 			return nil
 		}
 
-		return ve.loadPage(path)
-	})
+		if err := ve.loadPage(path); err != nil {
+			ve.app.logger.Error("xun: load html page", slog.String("path", path), slog.Any("err", err))
+		}
 
-	if err != nil && errors.Is(err, fs.ErrNotExist) {
 		return nil
-	}
-
-	return err
-
+	})
 }
 
 func (ve *HtmlViewEngine) loadPage(path string) error {
@@ -201,25 +163,19 @@ func (ve *HtmlViewEngine) loadPage(path string) error {
 	return nil
 }
 
-func (ve *HtmlViewEngine) loadViews() error {
-	err := fs.WalkDir(ve.fsys, "views", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
+func (ve *HtmlViewEngine) loadViews() {
+	fs.WalkDir(ve.fsys, "views", func(path string, d fs.DirEntry, _ error) error { // nolint: errcheck
 
-		if d.IsDir() || !strings.EqualFold(filepath.Ext(path), ".html") {
+		if d == nil || d.IsDir() || !strings.EqualFold(filepath.Ext(path), ".html") {
 			return nil
 		}
 
-		return ve.loadView(path)
-	})
+		if err := ve.loadView(path); err != nil {
+			ve.app.logger.Error("xun: load html view", slog.String("path", path), slog.Any("err", err))
+		}
 
-	if err != nil && errors.Is(err, fs.ErrNotExist) {
 		return nil
-	}
-
-	return err
-
+	})
 }
 
 func (ve *HtmlViewEngine) loadView(path string) error {

--- a/viewengine_html.go
+++ b/viewengine_html.go
@@ -82,7 +82,7 @@ func (ve *HtmlViewEngine) loadComponents() {
 		}
 
 		if _, err := ve.loadTemplate(path); err != nil {
-			ve.app.logger.Error("xun: load html components", slog.String("path", path), slog.Any("err", err))
+			ve.app.logger.Error("xun: load html", slog.String("path", path), slog.Any("err", err))
 		}
 		return nil
 	})
@@ -114,7 +114,7 @@ func (ve *HtmlViewEngine) loadLayouts() {
 
 		if strings.EqualFold(filepath.Ext(path), ".html") {
 			if _, err := ve.loadTemplate(path); err != nil {
-				ve.app.logger.Error("html: load html layouts", slog.String("path", path), slog.Any("err", err))
+				ve.app.logger.Error("xun: load html", slog.String("path", path), slog.Any("err", err))
 			}
 		}
 
@@ -130,7 +130,7 @@ func (ve *HtmlViewEngine) loadPages() {
 		}
 
 		if err := ve.loadPage(path); err != nil {
-			ve.app.logger.Error("xun: load html page", slog.String("path", path), slog.Any("err", err))
+			ve.app.logger.Error("xun: load html", slog.String("path", path), slog.Any("err", err))
 		}
 
 		return nil
@@ -171,7 +171,7 @@ func (ve *HtmlViewEngine) loadViews() {
 		}
 
 		if err := ve.loadView(path); err != nil {
-			ve.app.logger.Error("xun: load html view", slog.String("path", path), slog.Any("err", err))
+			ve.app.logger.Error("xun: load html", slog.String("path", path), slog.Any("err", err))
 		}
 
 		return nil

--- a/viewengine_static.go
+++ b/viewengine_static.go
@@ -1,7 +1,6 @@
 package xun
 
 import (
-	"errors"
 	"io/fs"
 	"reflect"
 	"strings"
@@ -19,7 +18,7 @@ type StaticViewEngine struct {
 // It scans the "public" directory in the given file system and registers each file
 // with the application. It also handles file changes for the "public" directory
 // and updates the application accordingly.
-func (ve *StaticViewEngine) Load(fsys fs.FS, app *App) error {
+func (ve *StaticViewEngine) Load(fsys fs.FS, app *App) {
 	root, err := fsys.Open(".")
 	if err == nil {
 		t := reflect.TypeOf(root)
@@ -28,23 +27,13 @@ func (ve *StaticViewEngine) Load(fsys fs.FS, app *App) error {
 		}
 	}
 
-	err = fs.WalkDir(fsys, "public", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if !d.IsDir() {
+	fs.WalkDir(fsys, "public", func(path string, d fs.DirEntry, err error) error { // nolint: errcheck
+		if d != nil && !d.IsDir() {
 			ve.handle(fsys, app, path)
 		}
 
 		return nil
 	})
-
-	if err != nil && errors.Is(err, fs.ErrNotExist) {
-		return nil
-	}
-
-	return err
 }
 
 // FileChanged handles file changes for the given file system and updates the


### PR DESCRIPTION
### Changed
-

### Fixed
- fix(viewengine): continue to load other files even a file is failed to load

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-tests` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Modify view engine loading to continue processing files even when individual file loading fails, improving error handling and resilience

Bug Fixes:
- Prevent view engine from stopping template loading when a single file fails to load

Enhancements:
- Modify view engine methods to log errors instead of stopping the entire loading process
- Update error handling to continue processing other files when one file fails