### PR TITLE
fix(sse): fixed connection leak issue

### DIFF
--- a/ext/acl/acl.go
+++ b/ext/acl/acl.go
@@ -42,7 +42,7 @@ func New(opts ...Option) xun.Middleware { // skipcq: GO-R1005
 
 			addr, _, err := net.SplitHostPort(c.Request.RemoteAddr)
 			if err != nil {
-				return ErrInvalidRemoteAddr
+				return next(c)
 			}
 
 			m := Model{
@@ -73,7 +73,7 @@ func New(opts ...Option) xun.Middleware { // skipcq: GO-R1005
 
 			ip := net.ParseIP(addr)
 			if ip == nil {
-				return ErrInvalidRemoteAddr
+				return next(c)
 			}
 
 			// in allow list

--- a/ext/acl/acl_test.go
+++ b/ext/acl/acl_test.go
@@ -16,7 +16,7 @@ func createContext(w http.ResponseWriter) *xun.Context {
 		w = httptest.NewRecorder()
 	}
 	return &xun.Context{
-		Request:  httptest.NewRequest(http.MethodGet, "/", nil),
+		Request:  httptest.NewRequest(http.MethodGet, "/", http.NoBody),
 		Response: xun.NewResponseWriter(w),
 	}
 }
@@ -54,19 +54,19 @@ func TestHosts(t *testing.T) {
 
 		ctx := createContext(nil)
 
-		ctx.Request = httptest.NewRequest(http.MethodGet, "http://123.com/status", nil)
+		ctx.Request = httptest.NewRequest(http.MethodGet, "http://123.com/status", http.NoBody)
 		err := m(nop)(ctx)
 		require.NoError(t, err)
 
-		ctx.Request = httptest.NewRequest(http.MethodGet, "http://123.com/ping", nil)
+		ctx.Request = httptest.NewRequest(http.MethodGet, "http://123.com/ping", http.NoBody)
 		err = m(nop)(ctx)
 		require.NoError(t, err)
 
-		ctx.Request = httptest.NewRequest(http.MethodGet, "http://123.com/home", nil)
+		ctx.Request = httptest.NewRequest(http.MethodGet, "http://123.com/home", http.NoBody)
 		err = m(nop)(ctx)
 		require.ErrorIs(t, err, xun.ErrCancelled)
 
-		ctx.Request = httptest.NewRequest(http.MethodGet, "http://abc.com/home", nil)
+		ctx.Request = httptest.NewRequest(http.MethodGet, "http://abc.com/home", http.NoBody)
 		err = m(nop)(ctx)
 		require.NoError(t, err)
 

--- a/ext/acl/acl_test.go
+++ b/ext/acl/acl_test.go
@@ -303,14 +303,14 @@ func TestCountries(t *testing.T) {
 	})
 }
 
-func TestInvalid(t *testing.T) {
+func TestIgnoreWhenConfigInvalid(t *testing.T) {
 	t.Run("invalid_remote_addr", func(t *testing.T) {
 		m := New()
 
 		ctx := createContext(nil)
 		ctx.Request.RemoteAddr = "2001:db8:85a3:0:0:8a2e:370:1]:1111"
 		err := m(nop)(ctx)
-		require.ErrorIs(t, err, ErrInvalidRemoteAddr)
+		require.NoError(t, err)
 	})
 	t.Run("invalid_remote_ip", func(t *testing.T) {
 		m := New()
@@ -318,6 +318,6 @@ func TestInvalid(t *testing.T) {
 		ctx := createContext(nil)
 		ctx.Request.RemoteAddr = "172.0:1"
 		err := m(nop)(ctx)
-		require.ErrorIs(t, err, ErrInvalidRemoteAddr)
+		require.NoError(t, err)
 	})
 }

--- a/ext/acl/helper.go
+++ b/ext/acl/helper.go
@@ -1,14 +1,11 @@
 package acl
 
 import (
-	"errors"
 	"net"
 	"net/http"
 
 	"github.com/yaitoo/xun"
 )
-
-var ErrInvalidRemoteAddr = errors.New("acl: invalid_remote_addr")
 
 // ParseIPNet parses the given IP address and returns its IPNet.
 // If the IP address does not have a netmask, the default netmask is used.

--- a/ext/form/binder.go
+++ b/ext/form/binder.go
@@ -2,6 +2,7 @@ package form
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/go-playground/form/v4"
 	"github.com/go-playground/validator/v10"
@@ -105,4 +106,12 @@ func (t *TEntity[T]) Validate(languages ...string) bool {
 	}
 
 	return false
+}
+
+func (t *TEntity[T]) Error() string {
+	var errs []string
+	for k, v := range t.Errors {
+		errs = append(errs, k+": "+v)
+	}
+	return strings.Join(errs, "\n")
 }

--- a/ext/form/binder_test.go
+++ b/ext/form/binder_test.go
@@ -96,7 +96,7 @@ func TestBinder(t *testing.T) {
 		{
 			"BindQuery",
 			func(it Login) *http.Request {
-				req, _ := http.NewRequest("GET", srv.URL+"/login?email="+url.QueryEscape(it.Email)+"&Passwd="+url.QueryEscape(it.Passwd), nil)
+				req, _ := http.NewRequest("GET", srv.URL+"/login?email="+url.QueryEscape(it.Email)+"&Passwd="+url.QueryEscape(it.Passwd), http.NoBody)
 				return req
 			},
 		},
@@ -194,7 +194,7 @@ func TestBinder(t *testing.T) {
 func TestInvalid(t *testing.T) {
 
 	t.Run("invalid_form", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
 		req.Body = nil
 		_, err := BindForm[int](req)
 		require.NotNil(t, err)

--- a/ext/form/binder_test.go
+++ b/ext/form/binder_test.go
@@ -185,6 +185,7 @@ func TestBinder(t *testing.T) {
 			require.Len(t, result.Errors, 2)
 			require.Equal(t, "Email必须是一个有效的邮箱", result.Errors["Email"])
 			require.Equal(t, "Passwd为必填字段", result.Errors["Passwd"])
+
 		})
 	}
 
@@ -202,4 +203,16 @@ func TestInvalid(t *testing.T) {
 		_, err := BindJson[int](httptest.NewRequest(http.MethodGet, "/", strings.NewReader(`"`)))
 		require.NotNil(t, err)
 	})
+}
+
+func TestError(t *testing.T) {
+	e := TEntity[any]{
+		Data:   nil,
+		Errors: map[string]string{"key": "value"},
+	}
+
+	e.Errors["key"] = "value"
+
+	require.Equal(t, "key: value", e.Error())
+
 }

--- a/ext/sse/client.go
+++ b/ext/sse/client.go
@@ -7,67 +7,61 @@ import (
 )
 
 var (
-	ErrClientClosed = errors.New("sse: client closed")
 	ErrServerClosed = errors.New("sse: server closed")
-	ErrClientJoined = errors.New("sse: client already joined")
 )
 
-// Conn represents a connection to a streaming service.
+// Client represents a connection to a streaming service.
 // It holds the client's ID, a Streamer instance for managing the stream,
 // a context for cancellation and timeout, and a channel for signaling closure.
-type Conn struct {
+type Client struct {
 	mu     sync.Mutex
 	ID     string
-	s      Streamer
+	connID int
+	sm     Streamer
 	ctx    context.Context
 	cancel context.CancelCauseFunc
-}
-
-// Connect establishes a connection for the Client using the provided Streamer.
-// It assigns the Streamer to the Client's rw field and ensures that it implements
-// the http.Flusher interface for flushing data.
-func (c *Conn) Connect(ctx context.Context, s Streamer) {
-	c.s = s
-	c.ctx, c.cancel = context.WithCancelCause(ctx)
 }
 
 // Send sends an event to the client by writing the event name and data to the response writer.
 // It marshals the event data into JSON format and flushes the output to ensure the data is sent immediately.
 // This method is part of the Client struct and is intended for use in server-sent events (SSE) communication.
-func (c *Conn) Send(evt Event) error {
+func (c *Client) Send(evt Event) error {
 	if c.ctx.Err() != nil {
-		return NewError(c.ID, ErrClientClosed)
+		return NewError(c.ID, context.Cause(c.ctx))
 	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	err := evt.Write(c.s)
+	err := evt.Write(c.sm)
 	if err != nil {
 		return NewError(c.ID, err)
 	}
 
-	c.s.Flush()
+	c.sm.Flush()
 
 	return nil
 }
 
-func (c *Conn) Context() context.Context {
+func (c *Client) Context() context.Context {
 	return c.ctx
 }
 
 // Wait blocks until the context is done or the client is closed.
 // It listens for either the cancellation of the context or a signal
 // to close the client, allowing for graceful shutdown.
-func (c *Conn) Wait() error {
-	ctx := c.ctx
-	<-ctx.Done()
+func (c *Client) Wait(ctx context.Context) error {
 
-	return ctx.Err()
+	select {
+	case <-c.ctx.Done():
+		return c.ctx.Err()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // Close gracefully shuts down the Client by sending a signal to the close channel.
 // This method should be called to ensure that any ongoing operations are properly terminated.
-func (c *Conn) Close() {
+func (c *Client) Close() {
 	c.cancel(ErrServerClosed)
 }

--- a/ext/sse/client.go
+++ b/ext/sse/client.go
@@ -54,9 +54,9 @@ func (c *Client) Wait(ctx context.Context) error {
 
 	select {
 	case <-c.ctx.Done():
-		return c.ctx.Err()
+		return context.Cause(c.ctx)
 	case <-ctx.Done():
-		return ctx.Err()
+		return context.Cause(ctx)
 	}
 }
 

--- a/ext/sse/conn.go
+++ b/ext/sse/conn.go
@@ -50,6 +50,10 @@ func (c *Conn) Send(evt Event) error {
 	return nil
 }
 
+func (c *Conn) Context() context.Context {
+	return c.ctx
+}
+
 // Wait blocks until the context is done or the client is closed.
 // It listens for either the cancellation of the context or a signal
 // to close the client, allowing for graceful shutdown.

--- a/ext/sse/conn.go
+++ b/ext/sse/conn.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	ErrClientClosed = errors.New("sse: client closed")
+	ErrClientJoined = errors.New("sse: client already joined")
 )
 
 // Conn represents a connection to a streaming service.

--- a/ext/sse/conn.go
+++ b/ext/sse/conn.go
@@ -16,7 +16,7 @@ var (
 // It holds the client's ID, a Streamer instance for managing the stream,
 // a context for cancellation and timeout, and a channel for signaling closure.
 type Conn struct {
-	sync.Mutex
+	mu     sync.Mutex
 	ID     string
 	s      Streamer
 	ctx    context.Context
@@ -39,8 +39,8 @@ func (c *Conn) Send(evt Event) error {
 		return NewError(c.ID, ErrClientClosed)
 	}
 
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	err := evt.Write(c.s)
 	if err != nil {

--- a/ext/sse/server.go
+++ b/ext/sse/server.go
@@ -4,14 +4,11 @@ package sse
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"sync"
 
 	"github.com/yaitoo/async"
 )
-
-var ErrClientJoined = errors.New("sse: client already joined")
 
 // Server represents a structure that manages connected clients
 // in a concurrent environment. It uses a read-write mutex to
@@ -42,8 +39,8 @@ func (s *Server) Join(ctx context.Context, id string, rw http.ResponseWriter) (*
 	_, ok := s.conns[id]
 	s.RUnlock()
 
-	if !ok {
-		return nil, ErrClientClosed
+	if ok {
+		return nil, ErrClientJoined
 	}
 
 	c := &Conn{

--- a/ext/sse/server.go
+++ b/ext/sse/server.go
@@ -15,7 +15,7 @@ import (
 // ensure safe access to the clients map, which holds the
 // active Client instances identified by their unique keys.
 type Server struct {
-	sync.RWMutex
+	mu    sync.RWMutex
 	conns map[string]*Conn
 }
 
@@ -35,11 +35,11 @@ func (s *Server) Join(ctx context.Context, id string, rw http.ResponseWriter) (*
 		return nil, err
 	}
 
-	s.Lock()
+	s.mu.Lock()
 	_, ok := s.conns[id]
 
 	if ok {
-		s.Unlock()
+		s.mu.Unlock()
 		return nil, ErrClientJoined
 	}
 
@@ -50,7 +50,7 @@ func (s *Server) Join(ctx context.Context, id string, rw http.ResponseWriter) (*
 	s.conns[id] = c
 
 	c.Connect(ctx, sm)
-	s.Unlock()
+	s.mu.Unlock()
 
 	sm.Header().Set("Content-Type", "text/event-stream")
 	sm.Header().Set("Cache-Control", "no-cache")

--- a/ext/sse/server.go
+++ b/ext/sse/server.go
@@ -47,7 +47,7 @@ func (s *Server) Join(ctx context.Context, id string, rw http.ResponseWriter) (*
 		ID: id,
 	}
 
-	s.Unlock()
+	s.Lock()
 	s.conns[id] = c
 	s.Unlock()
 

--- a/ext/sse/server_test.go
+++ b/ext/sse/server_test.go
@@ -319,15 +319,15 @@ func TestServer(t *testing.T) {
 type notFlusher struct {
 }
 
-func (s *notFlusher) Header() http.Header {
+func (*notFlusher) Header() http.Header {
 	return http.Header{}
 }
 
-func (s *notFlusher) Write([]byte) (int, error) {
+func (*notFlusher) Write([]byte) (int, error) {
 	return 0, errors.New("mock: invalid")
 }
 
-func (s *notFlusher) WriteHeader(int) {}
+func (*notFlusher) WriteHeader(int) {}
 
 type streamerMock struct {
 	http.ResponseWriter
@@ -343,6 +343,6 @@ type readCloser struct {
 	*bytes.Buffer
 }
 
-func (r *readCloser) Close() error {
+func (*readCloser) Close() error {
 	return nil
 }

--- a/ext/sse/server_test.go
+++ b/ext/sse/server_test.go
@@ -247,6 +247,29 @@ func TestServer(t *testing.T) {
 		require.Len(t, srv.clients, 0)
 	})
 
+	t.Run("client_wait", func(t *testing.T) {
+		srv := New()
+
+		rw := httptest.NewRecorder()
+
+		c, _, err := srv.Join("closed", rw)
+		require.NoError(t, err)
+		ctx, cf := context.WithCancel(context.Background())
+
+		c.Close()
+
+		err = c.Wait(ctx)
+		require.ErrorIs(t, err, ErrServerClosed)
+
+		c2, _, err := srv.Join("cancelled", rw)
+		require.NoError(t, err)
+		cf()
+
+		err = c2.Wait(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+
+	})
+
 	t.Run("send_with_gzip", func(t *testing.T) {
 		srv := New()
 		rw := httptest.NewRecorder()

--- a/ext/sse/server_test.go
+++ b/ext/sse/server_test.go
@@ -10,10 +10,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/yaitoo/async"
 	"github.com/yaitoo/xun"
 )
 
@@ -22,52 +20,52 @@ func TestServer(t *testing.T) {
 		srv := New()
 		rw := httptest.NewRecorder()
 
-		c1, err := srv.Join(context.TODO(), "join", nil)
+		c1, id, err := srv.Join("join", nil)
 		require.Nil(t, c1)
+		require.Equal(t, 0, id)
 		require.ErrorIs(t, err, ErrNotStreamer)
 
-		c1, err = srv.Join(context.TODO(), "join", &notStreamer{})
+		c1, id, err = srv.Join("join", &notFlusher{})
 		require.Nil(t, c1)
+		require.Equal(t, 0, id)
 		require.ErrorIs(t, err, ErrNotStreamer)
 
-		c1, err = srv.Join(context.TODO(), "join", rw)
+		c1, id, err = srv.Join("join", rw)
+		require.NotNil(t, c1)
 		require.NoError(t, err)
+		require.Equal(t, 1, id)
+		require.Equal(t, 1, c1.connID)
+		require.Nil(t, err)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		c2, err := srv.Join(ctx, "join", rw)
-		require.Nil(t, c2)
-		require.ErrorIs(t, err, ErrClientJoined)
-
-		c3, err := srv.MustJoin(ctx, "join", rw)
+		c2, id2, err := srv.Join("join", rw)
+		require.NotNil(t, c2)
+		require.Equal(t, 2, id2)
+		require.Equal(t, 2, c2.connID)
+		require.Equal(t, "join", c2.ID)
 		require.NoError(t, err)
+		require.Equal(t, c1, c2)
+
+		c3 := srv.Get("join")
 		require.Equal(t, c1, c3)
-		require.Equal(t, "join", c1.ID)
 
-		c4 := srv.Get("join")
+		ok := srv.Leave(c1.ID, id)
+		require.False(t, ok)
 
-		require.Equal(t, c1, c4)
+		c3 = srv.Get("join")
+		require.Equal(t, c1, c3)
 
-		go func() {
-			time.Sleep(1 * time.Second)
-			c3.Close()
-		}()
+		ok = srv.Leave(c1.ID, id2)
+		require.True(t, ok)
 
-		c3.Wait()
-		c4.Wait()
-
-		srv.Leave("join")
-
-		c5 := srv.Get("join")
-		require.Nil(t, c5)
-
+		c3 = srv.Get("join")
+		require.Nil(t, c3)
 	})
 
 	t.Run("send", func(t *testing.T) {
 		srv := New()
 		rw := httptest.NewRecorder()
 
-		c, err := srv.Join(context.TODO(), "send", rw)
+		c, _, err := srv.Join("send", rw)
 		require.NoError(t, err)
 
 		r := NewReader(&readCloser{Buffer: rw.Body})
@@ -161,11 +159,11 @@ func TestServer(t *testing.T) {
 		rw1 := httptest.NewRecorder()
 		rw2 := httptest.NewRecorder()
 
-		c1, err := srv.Join(context.TODO(), "c1", rw1)
+		c1, _, err := srv.Join("c1", rw1)
 		require.NotNil(t, c1)
 		require.NoError(t, err)
 
-		c2, err := srv.Join(context.TODO(), "c2", rw2)
+		c2, _, err := srv.Join("c2", rw2)
 		require.NotNil(t, c2)
 		require.NoError(t, err)
 
@@ -203,16 +201,14 @@ func TestServer(t *testing.T) {
 
 	})
 
-	t.Run("invalid", func(t *testing.T) {
+	t.Run("fail_to_send", func(t *testing.T) {
 		srv := New()
 
 		rw := &streamerMock{
 			ResponseWriter: httptest.NewRecorder(),
 		}
 
-		ctx, cancel := context.WithCancel(context.TODO())
-
-		c, err := srv.Join(ctx, "invalid", rw)
+		c, id, err := srv.Join("invalid", rw)
 		require.NoError(t, err)
 
 		err = c.Send(&JsonEvent{Name: "event1", Data: make(chan int)})
@@ -221,32 +217,34 @@ func TestServer(t *testing.T) {
 		err = c.Send(&TextEvent{Name: "event1"})
 		require.Error(t, err)
 
-		cancel()
+		srv.Leave(c.ID, id)
 
 		err = c.Send(&TextEvent{Name: "event1"})
-		require.ErrorIs(t, err, ErrClientClosed)
+		require.ErrorIs(t, err, ErrServerClosed)
 
-		errs, err := srv.Broadcast(context.TODO(), &TextEvent{Name: "event1", Data: "data1"})
-		require.ErrorIs(t, err, async.ErrTooLessDone)
-		require.Len(t, errs, 1)
+		c, id, err = srv.Join("invalid", rw)
+		require.NoError(t, err)
+		require.NotNil(t, c)
+		require.Equal(t, 1, id)
+
+		ctx, cf := context.WithCancelCause(context.Background())
+		cf(context.Canceled)
+
+		_, err = srv.Broadcast(ctx, &TextEvent{Name: "event1", Data: "data1"})
+		require.ErrorIs(t, err, context.Canceled)
 
 	})
 
 	t.Run("shutdown", func(t *testing.T) {
 		srv := New()
 
-		c1, err := srv.Join(context.TODO(), "c1", httptest.NewRecorder())
+		c1, _, err := srv.Join("c1", httptest.NewRecorder())
 		require.NoError(t, err)
 		require.NotNil(t, c1)
 
-		c2, err := srv.MustJoin(context.TODO(), "c1", httptest.NewRecorder())
-		require.NoError(t, err)
-		require.NotNil(t, c2)
 		srv.Shutdown()
-		c1.Wait()
-		c2.Wait()
 
-		require.Len(t, srv.conns, 0)
+		require.Len(t, srv.clients, 0)
 	})
 
 	t.Run("send_with_gzip", func(t *testing.T) {
@@ -255,7 +253,7 @@ func TestServer(t *testing.T) {
 
 		gc := &xun.GzipCompressor{}
 
-		c, err := srv.Join(context.TODO(), "send", gc.New(rw))
+		c, _, err := srv.Join("send", gc.New(rw))
 		require.NoError(t, err)
 
 		err = c.Send(&TextEvent{Name: "event1", Data: "data1"})
@@ -289,7 +287,7 @@ func TestServer(t *testing.T) {
 
 		gc := &xun.DeflateCompressor{}
 
-		c, err := srv.Join(context.TODO(), "send", gc.New(rw))
+		c, _, err := srv.Join("send", gc.New(rw))
 		require.NoError(t, err)
 
 		err = c.Send(&TextEvent{Name: "event1", Data: "data1"})
@@ -318,18 +316,18 @@ func TestServer(t *testing.T) {
 	})
 }
 
-type notStreamer struct {
+type notFlusher struct {
 }
 
-func (s *notStreamer) Header() http.Header {
+func (s *notFlusher) Header() http.Header {
 	return http.Header{}
 }
 
-func (s *notStreamer) Write([]byte) (int, error) {
+func (s *notFlusher) Write([]byte) (int, error) {
 	return 0, errors.New("mock: invalid")
 }
 
-func (s *notStreamer) WriteHeader(int) {}
+func (s *notFlusher) WriteHeader(int) {}
 
 type streamerMock struct {
 	http.ResponseWriter

--- a/ext/sse/server_test.go
+++ b/ext/sse/server_test.go
@@ -59,6 +59,9 @@ func TestServer(t *testing.T) {
 
 		c3 = srv.Get("join")
 		require.Nil(t, c3)
+
+		ok = srv.Leave(c1.ID, id2)
+		require.True(t, ok)
 	})
 
 	t.Run("send", func(t *testing.T) {
@@ -243,6 +246,9 @@ func TestServer(t *testing.T) {
 		require.NotNil(t, c1)
 
 		srv.Shutdown()
+
+		err = context.Cause(c1.Context())
+		require.ErrorIs(t, err, ErrServerClosed)
 
 		require.Len(t, srv.clients, 0)
 	})


### PR DESCRIPTION
### Changed
-

### Fixed
-

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-tests` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Prevent connection leaks by rejecting duplicate SSE client joins and improving concurrency control

Bug Fixes:
- Prevent duplicate SSE client connections in Server.Join by returning ErrClientJoined instead of reusing existing clients

Enhancements:
- Refactor locking in Server.Join to use read and write locks appropriately
- Add ErrClientJoined error and Conn.Context method to SSE connections