### PR TITLE
feat(ext/sse): added KeepAlive feature 

### DIFF
--- a/ext/sse/option.go
+++ b/ext/sse/option.go
@@ -1,0 +1,13 @@
+package sse
+
+import "time"
+
+type Option func(*Server)
+
+func WithKeepAlive(d time.Duration) Option {
+	return func(s *Server) {
+		if d > 0 {
+			s.keepalive = d
+		}
+	}
+}

--- a/ext/sse/option.go
+++ b/ext/sse/option.go
@@ -4,10 +4,10 @@ import "time"
 
 type Option func(*Server)
 
-func WithKeepAlive(d time.Duration) Option {
+func WithTimeout(d time.Duration) Option {
 	return func(s *Server) {
 		if d > 0 {
-			s.keepalive = d
+			s.timeout = d
 		}
 	}
 }

--- a/ext/sse/option.go
+++ b/ext/sse/option.go
@@ -4,10 +4,10 @@ import "time"
 
 type Option func(*Server)
 
-func WithTimeout(d time.Duration) Option {
+func WithClientTimeout(d time.Duration) Option {
 	return func(s *Server) {
 		if d > 0 {
-			s.timeout = d
+			s.clientTimeout = d
 		}
 	}
 }

--- a/ext/sse/server.go
+++ b/ext/sse/server.go
@@ -4,7 +4,6 @@ package sse
 
 import (
 	"context"
-	"log"
 	"net/http"
 	"sync"
 	"time"
@@ -78,7 +77,6 @@ func (s *Server) startKeepAlive() {
 
 				// lastSeen + timeout/2 < now
 				if lastSeen.Before(needPing) {
-					log.Println("ping: ", c.ID, c.lastSeen.Second(), now.Second())
 					go c.Send(&PingEvent{}) //nolint: errcheck
 				}
 

--- a/ext/sse/server_test.go
+++ b/ext/sse/server_test.go
@@ -20,35 +20,39 @@ func TestServer(t *testing.T) {
 		srv := New()
 		rw := httptest.NewRecorder()
 
-		c1, id, err := srv.Join("join", nil)
+		c1, id, ok, err := srv.Join("join", nil)
 		require.Nil(t, c1)
 		require.Equal(t, 0, id)
+		require.False(t, ok)
 		require.ErrorIs(t, err, ErrNotStreamer)
 
-		c1, id, err = srv.Join("join", &notFlusher{})
+		c1, id, ok, err = srv.Join("join", &notFlusher{})
 		require.Nil(t, c1)
 		require.Equal(t, 0, id)
+		require.False(t, ok)
 		require.ErrorIs(t, err, ErrNotStreamer)
 
-		c1, id, err = srv.Join("join", rw)
+		c1, id, ok, err = srv.Join("join", rw)
 		require.NotNil(t, c1)
 		require.NoError(t, err)
 		require.Equal(t, 1, id)
 		require.Equal(t, 1, c1.connID)
+		require.True(t, ok)
 		require.Nil(t, err)
 
-		c2, id2, err := srv.Join("join", rw)
+		c2, id2, ok, err := srv.Join("join", rw)
 		require.NotNil(t, c2)
 		require.Equal(t, 2, id2)
 		require.Equal(t, 2, c2.connID)
 		require.Equal(t, "join", c2.ID)
+		require.False(t, ok)
 		require.NoError(t, err)
 		require.Equal(t, c1, c2)
 
 		c3 := srv.Get("join")
 		require.Equal(t, c1, c3)
 
-		ok := srv.Leave(c1.ID, id)
+		ok = srv.Leave(c1.ID, id)
 		require.False(t, ok)
 
 		c3 = srv.Get("join")
@@ -68,7 +72,7 @@ func TestServer(t *testing.T) {
 		srv := New()
 		rw := httptest.NewRecorder()
 
-		c, _, err := srv.Join("send", rw)
+		c, _, _, err := srv.Join("send", rw)
 		require.NoError(t, err)
 
 		r := NewReader(&readCloser{Buffer: rw.Body})
@@ -162,11 +166,11 @@ func TestServer(t *testing.T) {
 		rw1 := httptest.NewRecorder()
 		rw2 := httptest.NewRecorder()
 
-		c1, _, err := srv.Join("c1", rw1)
+		c1, _, _, err := srv.Join("c1", rw1)
 		require.NotNil(t, c1)
 		require.NoError(t, err)
 
-		c2, _, err := srv.Join("c2", rw2)
+		c2, _, _, err := srv.Join("c2", rw2)
 		require.NotNil(t, c2)
 		require.NoError(t, err)
 
@@ -211,7 +215,7 @@ func TestServer(t *testing.T) {
 			ResponseWriter: httptest.NewRecorder(),
 		}
 
-		c, id, err := srv.Join("invalid", rw)
+		c, id, _, err := srv.Join("invalid", rw)
 		require.NoError(t, err)
 
 		err = c.Send(&JsonEvent{Name: "event1", Data: make(chan int)})
@@ -225,7 +229,7 @@ func TestServer(t *testing.T) {
 		err = c.Send(&TextEvent{Name: "event1"})
 		require.ErrorIs(t, err, ErrServerClosed)
 
-		c, id, err = srv.Join("invalid", rw)
+		c, id, _, err = srv.Join("invalid", rw)
 		require.NoError(t, err)
 		require.NotNil(t, c)
 		require.Equal(t, 1, id)
@@ -241,7 +245,7 @@ func TestServer(t *testing.T) {
 	t.Run("shutdown", func(t *testing.T) {
 		srv := New()
 
-		c1, _, err := srv.Join("c1", httptest.NewRecorder())
+		c1, _, _, err := srv.Join("c1", httptest.NewRecorder())
 		require.NoError(t, err)
 		require.NotNil(t, c1)
 
@@ -258,7 +262,7 @@ func TestServer(t *testing.T) {
 
 		rw := httptest.NewRecorder()
 
-		c, _, err := srv.Join("closed", rw)
+		c, _, _, err := srv.Join("closed", rw)
 		require.NoError(t, err)
 		ctx, cf := context.WithCancel(context.Background())
 
@@ -267,7 +271,7 @@ func TestServer(t *testing.T) {
 		err = c.Wait(ctx)
 		require.ErrorIs(t, err, ErrServerClosed)
 
-		c2, _, err := srv.Join("cancelled", rw)
+		c2, _, _, err := srv.Join("cancelled", rw)
 		require.NoError(t, err)
 		cf()
 
@@ -282,7 +286,7 @@ func TestServer(t *testing.T) {
 
 		gc := &xun.GzipCompressor{}
 
-		c, _, err := srv.Join("send", gc.New(rw))
+		c, _, _, err := srv.Join("send", gc.New(rw))
 		require.NoError(t, err)
 
 		err = c.Send(&TextEvent{Name: "event1", Data: "data1"})
@@ -316,7 +320,7 @@ func TestServer(t *testing.T) {
 
 		gc := &xun.DeflateCompressor{}
 
-		c, _, err := srv.Join("send", gc.New(rw))
+		c, _, _, err := srv.Join("send", gc.New(rw))
 		require.NoError(t, err)
 
 		err = c.Send(&TextEvent{Name: "event1", Data: "data1"})


### PR DESCRIPTION
### Changed
-

### Fixed
-

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-tests` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Implement configurable client timeout and KeepAlive support for SSE Server by adding WithClientTimeout option, health check loop with PingEvent and automatic disconnection of stale clients, updating Join signature, and extending tests accordingly

New Features:
- Add WithClientTimeout option to configure KeepAlive pings and automatic client timeout in SSE Server

Enhancements:
- Extend Server.Join to return an isNewClient flag and track lastSeen timestamp
- Implement a health check loop that sends periodic PingEvent and disconnects clients on timeout
- Introduce ErrClientTimeout and update Client.Send to refresh lastSeen

Tests:
- Update tests to assert the new Join signature and add timeout test with stdWriter and streamerMock for KeepAlive behavior