### PR TITLE
fix(ext/sse): use time.Sleep instead of time.NewTicker to fix cpu issue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,10 +43,7 @@ jobs:
           make unit-tests
           
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: yaitoo/xun
-          files: ./coverage.txt
-          flags: Unit-Tests
-          verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,11 @@ jobs:
           make unit-tests
           
       - name: Upload coverage reports to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.txt
+          flags: Unit-Tests
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        

--- a/ext/sse/option.go
+++ b/ext/sse/option.go
@@ -1,6 +1,8 @@
 package sse
 
-import "time"
+import (
+	"time"
+)
 
 type Option func(*Server)
 

--- a/ext/sse/server_test.go
+++ b/ext/sse/server_test.go
@@ -352,6 +352,8 @@ func TestServer(t *testing.T) {
 
 	t.Run("timeout", func(t *testing.T) {
 		srv := New(WithClientTimeout(3 * time.Second))
+		defer srv.Shutdown()
+		go srv.KeepAlive()
 		rw := &stdWriter{ResponseRecorder: httptest.NewRecorder()}
 
 		_, _, _, err := srv.Join("keepalive", rw)


### PR DESCRIPTION
### Changed
-

### Fixed
-

### Added
- 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-tests` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Use time.Sleep instead of a time.Ticker for the SSE server health check to fix CPU usage, introduce a configurable ClientTimeout, and rename/refactor the health check method and constructor.

New Features:
- Add ClientTimeout constant and clientTimeout field to configure SSE client timeouts

Bug Fixes:
- Replace ticker-based health check with Sleep to reduce CPU usage

Enhancements:
- Rename startHealthCheck to KeepAlive and refactor Server constructor for context initialization

Chores:
- Reformat import statements in option.go