### PR TITLE
feat: expose App.Mux() for native http.ServeMux registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,28 @@ app.Get("/posts/")       // matches GET /posts/abc, GET /posts/123
 app.Get("/posts")        // matches GET /posts  ONLY (no slash)
 ```
 
+### Rule 0.8 — `App.Mux()` handlers bypass xun entirely
+
+```go
+// app.Mux() exposes the underlying *http.ServeMux. Handlers registered
+// via app.Mux() do NOT run any middleware (app.Use OR group.Use), do NOT
+// go through c.View() / viewers, and do NOT emit X-Log-Id on failure.
+// They are responsible for their own status, headers, body, and logging.
+
+app.Mux().Handle("/metrics", promhttp.Handler())
+app.Mux().HandleFunc("/", customNotFound)   // catches unknown paths
+```
+
+Two footguns to know:
+
+- If you don't pass `WithMux`, `New()` uses `http.DefaultServeMux`.
+  Registering on it pollutes global state. Always pass
+  `WithMux(http.NewServeMux())` for new apps.
+- Patterns auto-registered by xun (e.g. `GET /{$}` from
+  `pages/index.html`) cannot be re-registered via `Mux()` — ServeMux
+  panics on duplicate patterns. Use `/` as a lower-precedence
+  catch-all instead.
+
 ---
 
 ## Section 1 — Types
@@ -177,6 +199,17 @@ app.Group(prefix string) *group
 ```
 
 Pattern format: `"METHOD pattern"` (e.g., `"GET /users/{id}"`). Go 1.22 ServeMux syntax.
+
+### 2.7 Native Routing Access
+
+```
+app.Mux() *http.ServeMux
+```
+
+`app.Mux()` is a *getter*, not a registration method: it returns the
+underlying `*http.ServeMux` so the caller can register `http.Handler` /
+`http.HandlerFunc` directly. See Rule 0.8 and Section 6.5 for semantics
+and footguns.
 
 ---
 
@@ -340,6 +373,54 @@ WithViewer(v ...Viewer) RoutingOption
 WithMetadata(key string, value any) RoutingOption
 WithNavigation(name, icon, access string) RoutingOption
 ```
+
+### 6.5 Native Routing via `App.Mux()`
+
+`app.Mux()` returns the underlying `*http.ServeMux` so callers can register
+`http.Handler` / `http.HandlerFunc` directly. This is the escape hatch for
+behaviour that xun's high-level API does not express — third-party
+`http.Handler` integrations (metrics, pprof), custom 404 fallbacks, or any
+endpoint that should not be wrapped by xun middlewares.
+
+**Semantics:**
+
+- Bypasses ALL middleware (both `app.Use` and `group.Use`).
+- Bypasses the viewer / content-negotiation path.
+- The handler is fully responsible for its own status, headers, body, and
+  logging; xun does not produce `X-Log-Id` or any error-to-status mapping.
+- Standard Go 1.22 ServeMux pattern syntax applies.
+- Routes registered via `Mux()` are NOT included in `app.Start()`'s startup
+  log (which iterates `app.routes`, not the underlying mux).
+
+**Footguns:**
+
+- If `WithMux` is not passed to `New()`, the underlying mux is
+  `http.DefaultServeMux`. Registering on it pollutes global state. Always
+  pass `WithMux(http.NewServeMux())` for new apps.
+- Patterns auto-registered by xun (notably `GET /{$}` from
+  `pages/index.html`, plus any `GET /path` for `pages/*.html`) cannot be
+  re-registered via `Mux()` — ServeMux panics on duplicate patterns. Use
+  `/` as a lower-precedence catch-all instead.
+
+**Common patterns:**
+
+```go
+// Catch-all 404 (lowest priority; specific routes still win).
+app.Mux().HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+    http.Error(w, "not found", http.StatusNotFound)
+})
+
+// Third-party handler.
+app.Mux().Handle("/metrics", promhttp.Handler())
+```
+
+Precedence: longer / more specific patterns win over `/`, so registering
+`app.Mux().HandleFunc("/", ...)` does not override any existing
+`app.Get/Post/HandlePage` route.
+
+> Note: `"GET /{$}"` matches only `/` (and only when no other route
+> matches), so it is NOT a general catch-all. For arbitrary unknown paths,
+> register `/` as shown above.
 
 ---
 

--- a/app.go
+++ b/app.go
@@ -150,6 +150,45 @@ func (app *App) Close() {
 	defer app.mu.Unlock()
 }
 
+// Mux returns the underlying *http.ServeMux. It is an escape hatch for
+// registering native http.Handlers directly, bypassing xun's routing
+// layer (middlewares, the viewer / content-negotiation path, and the
+// framework's error-to-status mapping).
+//
+// Use Mux when the caller needs behaviour that xun's high-level API
+// does not express, such as third-party http.Handler integrations or
+// catch-all fallback routes:
+//
+//	app.Mux().Handle("/metrics", promhttp.Handler())
+//	app.Mux().HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+//	    http.NotFound(w, r)
+//	})
+//
+// Patterns follow standard http.ServeMux rules. Handlers registered
+// via Mux bypass ALL middleware (both app.Use and group.Use) and are
+// fully responsible for their own status, headers, body, and logging;
+// they do not produce X-Log-Id on failure. Routes registered via Mux
+// are NOT listed by app.Start() — that method only iterates app.routes.
+//
+// Caveats:
+//
+//   - If WithMux is not provided, New() falls back to http.DefaultServeMux.
+//     Registering on DefaultServeMux pollutes global state and affects
+//     every other app in the same process. Pass WithMux(http.NewServeMux())
+//     to keep registrations local.
+//
+//   - Patterns auto-registered by xun (notably "GET /{$}" from
+//     pages/index.html) cannot be re-registered via Mux — ServeMux panics
+//     on duplicate patterns. Use "/" as a lower-precedence catch-all
+//     instead.
+//
+//   - Concurrent registration of the SAME pattern from multiple
+//     goroutines panics. Serialize registration, or register before
+//     serving starts.
+func (app *App) Mux() *http.ServeMux {
+	return app.mux
+}
+
 // Use registers one or more Middleware functions to be executed
 // before any route handler. Middleware functions are useful for
 // creating reusable pieces of code that can be composed together

--- a/app_test.go
+++ b/app_test.go
@@ -877,3 +877,154 @@ func TestAssetURL(t *testing.T) {
 	buf, _ = io.ReadAll(resp.Body)
 	require.Equal(t, "/assets/app.js", string(buf))
 }
+
+func TestMux(t *testing.T) {
+	t.Run("returns the injected mux", func(t *testing.T) {
+		mux := http.NewServeMux()
+		app := New(WithMux(mux))
+
+		require.Same(t, mux, app.Mux())
+	})
+
+	t.Run("registers a native handler bypassing xun middlewares and viewers", func(t *testing.T) {
+		mux := http.NewServeMux()
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		app := New(WithMux(mux))
+
+		var mwCount int
+		app.Use(func(next HandleFunc) HandleFunc {
+			return func(c *Context) error {
+				mwCount++
+				return next(c)
+			}
+		})
+
+		// Register a stdlib handler directly on the underlying mux.
+		app.Mux().HandleFunc("/raw", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusTeapot)
+			_, _ = w.Write([]byte("raw"))
+		})
+
+		app.Get("/xun", func(c *Context) error {
+			return c.View("xun")
+		})
+
+		app.Start()
+		defer app.Close()
+
+		req, err := http.NewRequest("GET", srv.URL+"/raw", nil)
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusTeapot, resp.StatusCode)
+		require.Equal(t, "text/plain", resp.Header.Get("Content-Type"))
+		require.Equal(t, "raw", string(body))
+		require.Empty(t, resp.Header.Get("X-Log-Id"))
+		require.Equal(t, 0, mwCount, "native handler must not run xun middlewares")
+
+		// Sanity check: xun route still works and increments the middleware counter.
+		req, err = http.NewRequest("GET", srv.URL+"/xun", nil)
+		require.NoError(t, err)
+		resp, err = client.Do(req)
+		require.NoError(t, err)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, 1, mwCount)
+	})
+
+	t.Run("fallback catches unknown paths while specific routes keep precedence", func(t *testing.T) {
+		mux := http.NewServeMux()
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		app := New(WithMux(mux))
+
+		// "/" is the lowest-precedence prefix in ServeMux, so it catches
+		// anything not matched by a more specific route.
+		app.Mux().HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Fallback", "yes")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("custom 404"))
+		})
+
+		app.Get("/known", func(c *Context) error {
+			return c.View("known")
+		})
+
+		app.Start()
+		defer app.Close()
+
+		// Unknown path → fallback handler runs.
+		req, err := http.NewRequest("GET", srv.URL+"/does-not-exist", nil)
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+		require.Equal(t, "yes", resp.Header.Get("X-Fallback"), "fallback handler must run for unknown paths")
+		require.Equal(t, "custom 404", string(body), "fallback body must be returned")
+		require.Empty(t, resp.Header.Get("X-Log-Id"), "fallback must not emit X-Log-Id")
+
+		// Specific xun route must still take precedence over the "/" fallback.
+		req, err = http.NewRequest("GET", srv.URL+"/known", nil)
+		require.NoError(t, err)
+		resp, err = client.Do(req)
+		require.NoError(t, err)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Empty(t, resp.Header.Get("X-Fallback"), "specific route must not match fallback")
+	})
+
+	t.Run("defaults to DefaultServeMux when WithMux is omitted (footgun — registering pollutes global state)", func(t *testing.T) {
+		app := New()
+		require.Same(t, http.DefaultServeMux, app.Mux(),
+			"calling New() without WithMux falls back to http.DefaultServeMux; "+
+				"callers should pass WithMux(http.NewServeMux()) to avoid registering on global state")
+	})
+
+	t.Run("supports http.Handler via Handle", func(t *testing.T) {
+		mux := http.NewServeMux()
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		app := New(WithMux(mux))
+
+		var hits int
+		// http.HandlerFunc adapts a function literal to http.Handler — this is
+		// the shape promhttp.Handler(), pprof.*, and similar third-party
+		// constructors return.
+		var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hits++
+			_, _ = w.Write([]byte("served by http.Handler"))
+		})
+
+		app.Mux().Handle("/metrics", handler)
+
+		app.Start()
+		defer app.Close()
+
+		req, err := http.NewRequest("GET", srv.URL+"/metrics", nil)
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, "served by http.Handler", string(body))
+		require.Equal(t, 1, hits)
+	})
+}


### PR DESCRIPTION
## Summary

Adds `App.Mux() *http.ServeMux` as an escape hatch for callers who need behaviour beyond xun's high-level API:

- Third-party `http.Handler` integrations (prometheus, pprof, grpc-gateway, ...)
- Custom 404 / catch-all fallback routes
- Any endpoint that should bypass `app.Use` / `group.Use` middlewares and the viewer/content-negotiation path

Routes registered via `Mux()` are not listed by `app.Start()` (which only iterates `app.routes`).

## Footguns documented

1. **`http.DefaultServeMux` fallback** — when `WithMux` is omitted from `New()`, `App.Mux()` returns the global `http.DefaultServeMux`. Registering on it pollutes global state. Always pass `WithMux(http.NewServeMux())`.

2. **Pattern conflicts with xun auto-registrations** — patterns like `GET /{$}` (auto-registered by `pages/index.html`) and `GET /path` (auto-registered by `pages/path.html`) cannot be re-registered via `Mux()` — `ServeMux` panics. Use `/` as a lower-precedence catch-all instead.

## Changes

- `app.go`: `Mux()` getter with full doc comment covering semantics, caveats, and concurrency notes
- `app_test.go`: `TestMux` with 5 subtests covering getter identity, native-handler bypass, fallback precedence, DefaultServeMux fallback, and `http.Handler` via `Handle`
- `README.md`:
  - New **Rule 0.8** — quick warning at the top
  - New **Section 2.7** Native Routing Access — getter contract
  - New **Section 6.5** Native Routing via `App.Mux()` — canonical API reference with semantics + footguns + common patterns

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` — 13 packages pass
- [x] `TestMux` — 5/5 subtests pass:
  - `returns the injected mux`
  - `registers a native handler bypassing xun middlewares and viewers`
  - `fallback catches unknown paths while specific routes keep precedence`
  - `defaults to DefaultServeMux when WithMux is omitted (footgun — registering pollutes global state)`
  - `supports http.Handler via Handle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Expose the underlying http.ServeMux via App.Mux() as an escape hatch for native routing that bypasses xun’s middleware and viewer pipeline.

New Features:
- Add App.Mux() getter to return the underlying *http.ServeMux for direct http.Handler/http.HandlerFunc registration.

Enhancements:
- Document App.Mux() semantics, caveats, and common usage patterns in the README, including precedence rules and interaction with xun’s auto-registered routes.

Tests:
- Add TestMux coverage to verify mux injection, middleware bypass behavior, fallback routing via "/", DefaultServeMux fallback when WithMux is omitted, and support for http.Handler via Handle.