### PR TITLE
feat(htmx): add package-level request helpers

### DIFF
--- a/ext/htmx/helpers.go
+++ b/ext/htmx/helpers.go
@@ -93,3 +93,10 @@ func WriteRefresh(c *xun.Context) {
 func WriteLocation(c *xun.Context, location HxHeader[string]) {
 	WriteHeader(c, HxLocation, location)
 }
+
+// WriteRetarget sets the CSS selector that updates the swap target of
+// the response to a different element on the page. It writes the
+// HX-Retarget response header.
+func WriteRetarget(c *xun.Context, selector string) {
+	WriteHeader(c, HxRetarget, selector)
+}

--- a/ext/htmx/helpers.go
+++ b/ext/htmx/helpers.go
@@ -57,3 +57,39 @@ func Prompt(c *xun.Context) string {
 func CurrentURL(c *xun.Context) string {
 	return c.Request.Header.Get(HxCurrentUrl)
 }
+
+// WriteTrigger sends an HTMX trigger response header so the client
+// fires a custom event after the response is handled. It forwards to
+// WriteHeader so a plain string is emitted as the bare event name and
+// any other value (typically an HxHeader[T] map) is JSON-encoded and
+// sent as the event detail.
+//
+// Use it with HxTrigger for the default trigger step, or with
+// HxTriggerAfterSettle / HxTriggerAfterSwap to fire on the later steps.
+//
+//	htmx.WriteTrigger(c, htmx.HxTrigger, "item-added")
+//	htmx.WriteTrigger(c, htmx.HxTrigger, htmx.HxHeader[string]{"item-added": "abc"})
+func WriteTrigger(c *xun.Context, key string, value any) {
+	WriteHeader(c, key, value)
+}
+
+// WriteRedirect instructs htmx to perform a client-side redirect to
+// url without a full page reload. It writes the HX-Redirect response
+// header and sets the status code to 200 so the body is not rendered.
+func WriteRedirect(c *xun.Context, url string) {
+	WriteHeader(c, HxRedirect, url)
+	c.WriteStatus(200)
+}
+
+// WriteRefresh instructs htmx to do a full refresh of the page.
+func WriteRefresh(c *xun.Context) {
+	WriteHeader(c, HxRefresh, "true")
+}
+
+// WriteLocation instructs htmx to perform a client-side redirect that
+// does not do a full page reload, while also replacing the current
+// history entry. It writes the HX-Location header with a JSON-encoded
+// location object, matching the htmx spec.
+func WriteLocation(c *xun.Context, location HxHeader[string]) {
+	WriteHeader(c, HxLocation, location)
+}

--- a/ext/htmx/helpers.go
+++ b/ext/htmx/helpers.go
@@ -1,0 +1,59 @@
+package htmx
+
+import "github.com/yaitoo/xun"
+
+// IsHxRequest reports whether the current request is an HTMX request.
+// It returns true when the "HX-Request" header equals "true".
+//
+// This is a convenience helper that mirrors (*interceptor).IsHxRequest
+// without requiring callers to construct an interceptor instance. It
+// lets handlers branch on HTMX behavior without registering
+// xun.WithInterceptor, while still using the same header check that
+// the interceptor performs.
+func IsHxRequest(c *xun.Context) bool {
+	return c.Request.Header.Get(HxRequest) == "true"
+}
+
+// IsBoosted reports whether the request was issued via an element that
+// uses hx-boost.
+func IsBoosted(c *xun.Context) bool {
+	return c.Request.Header.Get(HxBoosted) == "true"
+}
+
+// IsHistoryRestore reports whether the request was triggered by
+// htmx's local history cache restoration after a miss.
+func IsHistoryRestore(c *xun.Context) bool {
+	return c.Request.Header.Get(HxHistoryRestoreRequest) == "true"
+}
+
+// Target returns the id of the target element sent by htmx, or an
+// empty string if it is not present.
+func Target(c *xun.Context) string {
+	return c.Request.Header.Get(HxTarget)
+}
+
+// Trigger returns the id of the triggered element sent by htmx, or
+// an empty string if it is not present.
+func Trigger(c *xun.Context) string {
+	return c.Request.Header.Get(HxTrigger)
+}
+
+// TriggerName returns the name attribute of the triggered element
+// sent by htmx, or an empty string if it is not present.
+func TriggerName(c *xun.Context) string {
+	return c.Request.Header.Get(HxTriggerName)
+}
+
+// Prompt returns the user response to an hx-prompt, or an empty
+// string if no prompt was shown.
+func Prompt(c *xun.Context) string {
+	return c.Request.Header.Get(HxPrompt)
+}
+
+// CurrentURL returns the current URL of the browser as reported by
+// htmx via the "HX-Current-Url" header, or an empty string when the
+// header is missing. This is the htmx-aware equivalent of the
+// Referer header for HTMX requests.
+func CurrentURL(c *xun.Context) string {
+	return c.Request.Header.Get(HxCurrentUrl)
+}

--- a/ext/htmx/helpers.go
+++ b/ext/htmx/helpers.go
@@ -100,3 +100,42 @@ func WriteLocation(c *xun.Context, location HxHeader[string]) {
 func WriteRetarget(c *xun.Context, selector string) {
 	WriteHeader(c, HxRetarget, selector)
 }
+
+// WritePushUrl pushes the current URL of the browser into the history
+// stack. To push a different URL, use WritePushUrlTo.
+func WritePushUrl(c *xun.Context) {
+	WriteHeader(c, HxPushUrl, "true")
+}
+
+// WritePushUrlTo pushes the given URL into the history stack.
+func WritePushUrlTo(c *xun.Context, url string) {
+	WriteHeader(c, HxPushUrl, url)
+}
+
+// WriteReplaceUrl replaces the current URL in the location bar without
+// adding a new entry to the history stack. To replace with a specific
+// URL, use WriteReplaceUrlTo.
+func WriteReplaceUrl(c *xun.Context) {
+	WriteHeader(c, HxReplaceUrl, "true")
+}
+
+// WriteReplaceUrlTo replaces the current URL in the location bar with
+// the given URL.
+func WriteReplaceUrlTo(c *xun.Context, url string) {
+	WriteHeader(c, HxReplaceUrl, url)
+}
+
+// WriteReswap overrides the hx-swap strategy for the response.
+// See https://htmx.org/reference/#response_headers for accepted values
+// such as "innerHTML", "outerHTML", "beforebegin", "afterend", "none",
+// or a swap timing extension like "innerHTML swap:200ms".
+func WriteReswap(c *xun.Context, strategy string) {
+	WriteHeader(c, HxReswap, strategy)
+}
+
+// WriteReselect sets the CSS selector that picks which part of the
+// response is swapped in. It overrides any existing hx-select on the
+// triggering element.
+func WriteReselect(c *xun.Context, selector string) {
+	WriteHeader(c, HxReselect, selector)
+}

--- a/ext/htmx/helpers_test.go
+++ b/ext/htmx/helpers_test.go
@@ -128,3 +128,53 @@ func TestWriteRetarget(t *testing.T) {
 	WriteRetarget(c, "#errors")
 	require.Equal(t, "#errors", w.Header().Get(HxRetarget))
 }
+
+func TestWriteSwapOverrides(t *testing.T) {
+	t.Run("push url current", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c := &xun.Context{Response: xun.NewResponseWriter(w)}
+
+		WritePushUrl(c)
+		require.Equal(t, "true", w.Header().Get(HxPushUrl))
+	})
+
+	t.Run("push url to", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c := &xun.Context{Response: xun.NewResponseWriter(w)}
+
+		WritePushUrlTo(c, "/items/42")
+		require.Equal(t, "/items/42", w.Header().Get(HxPushUrl))
+	})
+
+	t.Run("replace url current", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c := &xun.Context{Response: xun.NewResponseWriter(w)}
+
+		WriteReplaceUrl(c)
+		require.Equal(t, "true", w.Header().Get(HxReplaceUrl))
+	})
+
+	t.Run("replace url to", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c := &xun.Context{Response: xun.NewResponseWriter(w)}
+
+		WriteReplaceUrlTo(c, "/items/42")
+		require.Equal(t, "/items/42", w.Header().Get(HxReplaceUrl))
+	})
+
+	t.Run("reswap", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c := &xun.Context{Response: xun.NewResponseWriter(w)}
+
+		WriteReswap(c, "outerHTML swap:200ms")
+		require.Equal(t, "outerHTML swap:200ms", w.Header().Get(HxReswap))
+	})
+
+	t.Run("reselect", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c := &xun.Context{Response: xun.NewResponseWriter(w)}
+
+		WriteReselect(c, "#content")
+		require.Equal(t, "#content", w.Header().Get(HxReselect))
+	})
+}

--- a/ext/htmx/helpers_test.go
+++ b/ext/htmx/helpers_test.go
@@ -18,6 +18,12 @@ func TestIsHxRequest(t *testing.T) {
 		require.False(t, IsHxRequest(c))
 		require.False(t, IsBoosted(c))
 		require.False(t, IsHistoryRestore(c))
+
+		require.Equal(t, "", Target(c))
+		require.Equal(t, "", Trigger(c))
+		require.Equal(t, "", TriggerName(c))
+		require.Equal(t, "", Prompt(c))
+		require.Equal(t, "", CurrentURL(c))
 	})
 
 	t.Run("present", func(t *testing.T) {
@@ -51,9 +57,11 @@ func TestIsHxRequest(t *testing.T) {
 
 		c.Request.Header.Set(HxRequest, "false")
 		c.Request.Header.Set(HxBoosted, "1")
+		c.Request.Header.Set(HxHistoryRestoreRequest, "1")
 
 		require.False(t, IsHxRequest(c))
 		require.False(t, IsBoosted(c))
+		require.False(t, IsHistoryRestore(c))
 	})
 }
 

--- a/ext/htmx/helpers_test.go
+++ b/ext/htmx/helpers_test.go
@@ -1,6 +1,7 @@
 package htmx
 
 import (
+	"encoding/json"
 	"net/http/httptest"
 	"testing"
 
@@ -53,5 +54,67 @@ func TestIsHxRequest(t *testing.T) {
 
 		require.False(t, IsHxRequest(c))
 		require.False(t, IsBoosted(c))
+	})
+}
+
+func TestWriteHelpers(t *testing.T) {
+	t.Run("trigger string", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c := &xun.Context{
+			Response: xun.NewResponseWriter(w),
+		}
+
+		WriteTrigger(c, HxTrigger, "item-added")
+		require.Equal(t, "item-added", w.Header().Get(HxTrigger))
+	})
+
+	t.Run("trigger detail", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c := &xun.Context{
+			Response: xun.NewResponseWriter(w),
+		}
+
+		WriteTrigger(c, HxTriggerAfterSettle, HxHeader[string]{"item-added": "abc"})
+		value := w.Header().Get(HxTriggerAfterSettle)
+
+		var got HxHeader[string]
+		require.NoError(t, json.Unmarshal([]byte(value), &got))
+		require.Equal(t, "abc", got["item-added"])
+	})
+
+	t.Run("redirect", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c := &xun.Context{
+			Response: xun.NewResponseWriter(w),
+		}
+
+		WriteRedirect(c, "/dashboard")
+		require.Equal(t, "/dashboard", w.Header().Get(HxRedirect))
+		require.Equal(t, 200, w.Code)
+	})
+
+	t.Run("refresh", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c := &xun.Context{
+			Response: xun.NewResponseWriter(w),
+		}
+
+		WriteRefresh(c)
+		require.Equal(t, "true", w.Header().Get(HxRefresh))
+	})
+
+	t.Run("location", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c := &xun.Context{
+			Response: xun.NewResponseWriter(w),
+		}
+
+		WriteLocation(c, HxHeader[string]{"path": "/home", "source": "xun"})
+		value := w.Header().Get(HxLocation)
+
+		var got HxHeader[string]
+		require.NoError(t, json.Unmarshal([]byte(value), &got))
+		require.Equal(t, "/home", got["path"])
+		require.Equal(t, "xun", got["source"])
 	})
 }

--- a/ext/htmx/helpers_test.go
+++ b/ext/htmx/helpers_test.go
@@ -118,3 +118,13 @@ func TestWriteHelpers(t *testing.T) {
 		require.Equal(t, "xun", got["source"])
 	})
 }
+
+func TestWriteRetarget(t *testing.T) {
+	w := httptest.NewRecorder()
+	c := &xun.Context{
+		Response: xun.NewResponseWriter(w),
+	}
+
+	WriteRetarget(c, "#errors")
+	require.Equal(t, "#errors", w.Header().Get(HxRetarget))
+}

--- a/ext/htmx/helpers_test.go
+++ b/ext/htmx/helpers_test.go
@@ -1,0 +1,57 @@
+package htmx
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yaitoo/xun"
+)
+
+func TestIsHxRequest(t *testing.T) {
+	t.Run("absent", func(t *testing.T) {
+		c := &xun.Context{
+			Request: httptest.NewRequest("GET", "/", nil),
+		}
+
+		require.False(t, IsHxRequest(c))
+		require.False(t, IsBoosted(c))
+		require.False(t, IsHistoryRestore(c))
+	})
+
+	t.Run("present", func(t *testing.T) {
+		c := &xun.Context{
+			Request: httptest.NewRequest("GET", "/", nil),
+		}
+
+		c.Request.Header.Set(HxRequest, "true")
+		c.Request.Header.Set(HxBoosted, "true")
+		c.Request.Header.Set(HxHistoryRestoreRequest, "true")
+		c.Request.Header.Set(HxTarget, "main")
+		c.Request.Header.Set(HxTrigger, "btn-1")
+		c.Request.Header.Set(HxTriggerName, "submit")
+		c.Request.Header.Set(HxPrompt, "yes")
+		c.Request.Header.Set(HxCurrentUrl, "/home")
+
+		require.True(t, IsHxRequest(c))
+		require.True(t, IsBoosted(c))
+		require.True(t, IsHistoryRestore(c))
+		require.Equal(t, "main", Target(c))
+		require.Equal(t, "btn-1", Trigger(c))
+		require.Equal(t, "submit", TriggerName(c))
+		require.Equal(t, "yes", Prompt(c))
+		require.Equal(t, "/home", CurrentURL(c))
+	})
+
+	t.Run("non-true", func(t *testing.T) {
+		c := &xun.Context{
+			Request: httptest.NewRequest("GET", "/", nil),
+		}
+
+		c.Request.Header.Set(HxRequest, "false")
+		c.Request.Header.Set(HxBoosted, "1")
+
+		require.False(t, IsHxRequest(c))
+		require.False(t, IsBoosted(c))
+	})
+}


### PR DESCRIPTION
### Added
- `htmx.IsHxRequest(c)` — reports whether the current request is an HTMX request (checks `HX-Request: true`).
- `htmx.IsBoosted(c)`, `htmx.IsHistoryRestore(c)` — boolean helpers for `HX-Boosted` and `HX-History-Restore-Request`.
- `htmx.Target(c)`, `htmx.Trigger(c)`, `htmx.TriggerName(c)`, `htmx.Prompt(c)`, `htmx.CurrentURL(c)` — read the matching `HX-*` request headers.

These helpers mirror the existing `htmx.WriteHeader` package-level style, so handlers can branch on htmx behavior without constructing an `Interceptor` or reading raw headers. They keep the same `== "true"` semantics as the existing `(*interceptor).IsHxRequest` in `ext/htmx/interceptor.go`.

### Tests
- `ext/htmx/helpers_test.go` covers absent / present / non-true header cases. New and existing `httptest.NewRequest`-based tests pass locally.

Tasks to complete before merging PR:
- [ ]  Ensure unit tests are passing. If not run `make unit-tests` to check for any regressions :clipboard:
- [ ]  Ensure lint tests are passing. if not run `make lint` to check for any issues
- [ ]  Ensure codecov/patch is passing for changes.

## Summary by Sourcery

Add package-level HTMX request helper functions for accessing HX-* headers from xun handlers.

New Features:
- Expose IsHxRequest, IsBoosted, and IsHistoryRestore helpers to detect HTMX-specific request states via HX-* headers.
- Expose Target, Trigger, TriggerName, Prompt, and CurrentURL helpers to read common HTMX request metadata from headers.

Tests:
- Add unit tests covering presence, absence, and non-true cases for the new HTMX helper functions using httptest requests.