### PR TITLE
feat(viewer): expose ancestor chain as ViewModel.Breadcrumb

### DIFF
--- a/docs/breadcrumb.md
+++ b/docs/breadcrumb.md
@@ -1,0 +1,232 @@
+# Breadcrumb Design
+
+> Status: DESIGN — Phase 1 implementation pending
+> Companion to `content.md`. Extends `HtmlViewEngine` with ancestor-aware navigation data.
+
+This document describes how xun surfaces a breadcrumb chain to HTML templates. The mechanism is deliberately minimal: it walks the request URL, pairs each ancestor with its Markdown H1 (when available), and exposes the chain as `ViewModel.Breadcrumb`. There is no new file convention, no new option, no new template function — only data.
+
+---
+
+## Section 0 — Design Principles
+
+### Principle 0.1 — Data only, no UI coupling
+
+The breadcrumb feature produces a `[]BreadcrumbItem` slice and nothing else. No template function, no JSON-LD helper, no schema.org generator, no `WithBreadcrumb(false)` toggle. Templates and handlers consume the slice directly. Anything that resembles rendering or presentation stays in user code.
+
+### Principle 0.2 — No new metadata infrastructure
+
+There is no `pageMeta` map, no `<!--meta:K=V-->` comment parser, no `WithPageMeta` routing option. The breadcrumb is computed from two sources that already exist:
+
+1. `ctx.Request.URL.Path` (URL segments).
+2. `App.contentViews` (Markdown H1s, populated by the content engine per `content.md`).
+
+If a future feature needs cross-route page metadata, it builds its own store. Breadcrumb does not introduce one.
+
+### Principle 0.3 — `Name` and `Title` are distinct
+
+- `Name` is the **link label** rendered inside `<a>`. It comes from the URL segment, verbatim, with no transformation.
+- `Title` is the **hover tooltip** rendered as the `title` attribute. It comes from `ContentView.Title` (the Markdown H1) and is empty for non-Markdown ancestors.
+
+These two fields answer different questions: "what does the user see?" versus "what extra context does the page offer on hover?". Conflating them — as a single "title" or "label" field — loses information.
+
+### Principle 0.4 — Current page is the last item
+
+The chain includes the current page as the trailing element with `Last == true`. Templates identify the current page by this flag, not by string comparison against the request URL (which is not visible inside templates anyway). "父辈" in the original discussion is loose: in this design, the array means "the full breadcrumb chain", ancestors in the strict-graph sense.
+
+### Principle 0.5 — Root path produces an empty chain
+
+`GET /{$}` has no ancestors. `vm.Breadcrumb` is `nil`. Templates guard with `{{if .Breadcrumb}}` or `{{with .Breadcrumb}}` and degrade gracefully.
+
+---
+
+## Section 1 — Data Structure
+
+```go
+// BreadcrumbItem is one node in the breadcrumb chain rendered into templates.
+//
+//   Path  — the URL prefix leading to this node, including leading slash.
+//           The root item has Path = "/".
+//   Name  — the link label, equal to the last segment of Path verbatim.
+//           The root item has Name = "Home" (fixed constant).
+//   Title — hover hint, sourced from ContentView.Title (Markdown H1).
+//           Empty for non-Markdown ancestors.
+//   Last  — true on the trailing item (current page). Templates use this
+//           to decide between <a> and <span>, instead of comparing paths.
+type BreadcrumbItem struct {
+    Path  string
+    Name  string
+    Title string
+    Last  bool
+}
+
+// ViewModel gains one field. Existing TempData, Data, Content are unchanged.
+type ViewModel struct {
+    TempData   map[string]any
+    Data       any
+    Content    *ContentView
+    Breadcrumb []BreadcrumbItem // top → bottom, trailing = current page; nil on root
+}
+```
+
+The slice is ordered top-to-bottom: `items[0]` is the root, `items[len-1]` is the current page. JSON-LD emission (out of scope for this document) iterates the slice in order.
+
+---
+
+## Section 2 — Construction Algorithm
+
+`HtmlViewer.Render` builds `vm.Breadcrumb` immediately after the existing `vm.Content` lookup, before `template.Execute`:
+
+```go
+path := strings.Trim(ctx.Request.URL.Path, "/")
+if path == "" {
+    vm.Breadcrumb = nil
+    return // root: no chain
+}
+
+segs := strings.Split(path, "/")
+items := make([]BreadcrumbItem, 0, len(segs)+1)
+
+// Root: fixed label, no metadata lookup.
+items = append(items, BreadcrumbItem{Path: "/", Name: "Home"})
+
+// Ancestors + current page, in URL order.
+for i, seg := range segs {
+    prefix := "/" + strings.Join(segs[:i+1], "/")
+    pattern := "GET " + prefix
+
+    title := ""
+    if cv := ctx.App.lookupContent(pattern); cv != nil && cv.Title != "" {
+        title = cv.Title
+    }
+
+    items = append(items, BreadcrumbItem{
+        Path:  prefix,
+        Name:  seg,
+        Title: title,
+    })
+}
+
+items[len(items)-1].Last = true
+vm.Breadcrumb = items
+```
+
+Three notes:
+
+1. **`Name` is the raw segment.** No `humanize`, no `title-case`, no decoding. "deep-dive" stays "deep-dive". Templates or template funcs may post-process if they want; the framework does not assume an English kebab-case convention.
+2. **Root `Name` is hardcoded to `"Home"`.** There is no override path in this design. Localized sites translate in templates or supply a custom viewer. See Section 5 for the rationale.
+3. **`Title` is set per ancestor independently.** Each prefix performs its own `lookupContent`, so a Markdown post at `/blog/2026/x.md` carries its own H1 while its parent `index.md` carries a different one.
+
+---
+
+## Section 3 — File Changes
+
+Two files, additive only.
+
+| File | Change |
+|---|---|
+| `viewer.go` | Add `BreadcrumbItem` type. Add `Breadcrumb []BreadcrumbItem` field to `ViewModel`. |
+| `viewer_html.go` | In `Render`, after the existing `lookupContent` branch, build `vm.Breadcrumb` per Section 2. |
+
+No other files change. `template_html.go`, `viewengine_html.go`, `routing_option.go`, `app.go`, `option.go`, and `funcmap.go` are untouched.
+
+---
+
+## Section 4 — Template Usage
+
+A layout-level component renders the chain. The minimum is:
+
+```html
+<nav aria-label="breadcrumb"><ol>
+{{range .Breadcrumb}}
+<li>{{if .Last}}{{.Name}}{{else}}<a href="{{.Path}}"{{with .Title}} title="{{.}}"{{end}}>{{.Name}}</a>{{end}}</li>
+{{end}}
+</ol></nav>
+```
+
+The `Last` branch renders the current page as a plain `<li>` (no link, no `title` attribute even when empty). The non-`Last` branch renders an `<a>` whose `title` attribute is omitted when `Title` is empty thanks to `{{with}}`.
+
+For sites that want richer markup (schema.org JSON-LD, microdata, custom CSS classes), iterate the same slice and emit whatever structure the design system requires. No framework helper is involved.
+
+---
+
+## Section 5 — Deliberate Non-Goals
+
+The following are out of scope by design. Each is one bullet because none merits a paragraph until a real use case demands it.
+
+- **No page-meta comment parser.** `<!--meta:K=V-->` is not introduced. `pageMeta` does not exist.
+- **No `WithPageMeta` routing option.** Code-defined routes that need breadcrumb overrides manipulate `vm.Breadcrumb` in the handler (see Section 6).
+- **No `WithNavigation` integration.** `WithNavigation` continues to populate `Routing.Options.metadata` for code-side consumption. It is not mirrored into a breadcrumb store. If a future feature needs the navigation tree, that is a separate design document.
+- **No `Home` override.** Root `Name` is the literal string `"Home"`. Localization or rename is the user's responsibility, handled in the layout template or via a custom viewer.
+- **No `humanize` on segments.** "deep-dive" stays "deep-dive". The framework does not encode assumptions about URL conventions.
+- **No JSON-LD helper.** Templates or a future extension emit schema.org markup.
+- **No `WithBreadcrumb(false)` toggle.** To suppress the chain, render `{{if false}}` around the `range` or omit the layout component. The framework always computes it; computation is one map lookup per ancestor plus one allocation.
+- **No dynamic-segment special case.** `/user/{id}` produces a trailing item whose `Name` is the literal ID (`"42"`). Handlers needing a friendly name override in `vm.Breadcrumb` after construction (Section 6).
+- **No multi-host awareness.** `@abc.com/...` pages are not addressed in this design.
+
+---
+
+## Section 6 — Handler Overrides
+
+When the default segment-derived `Name` is wrong (dynamic routes, renamed slugs, i18n), the handler adjusts the slice after the viewer has built it. Two patterns:
+
+**Mutate the trailing item** (typical for `/user/{id}`):
+
+```go
+app.Get("/user/{id}", func(c *Context) error {
+    u := loadUser(c.Request.PathValue("id"))
+    // The viewer ran before us? No — Render runs after the handler returns.
+    // We can't mutate vm.Breadcrumb post-hoc; instead set a TempData hint
+    // and let the layout apply it.
+    c.Set("currentName", u.DisplayName)
+    return c.View(u)
+})
+```
+
+Layout consumes the hint:
+
+```html
+{{$current := ""}}
+{{with .TempData.currentName}}{{$current = .}}{{end}}
+{{range .Breadcrumb}}
+<li>{{if .Last}}{{if $current}}{{$current}}{{else}}{{.Name}}{{end}}{{else}}<a href="{{.Path}}">{{.Name}}</a>{{end}}</li>
+{{end}}
+```
+
+This keeps the framework's contract intact — `vm.Breadcrumb` is always populated, never partially — while letting handlers localize the current label through `TempData`.
+
+**Rebuild the chain** (rare; only when ancestors themselves differ):
+
+For now, this is not supported by the framework API. If a real case emerges, a `Context.RebuildBreadcrumb(...)` helper can be added without breaking this design — `BreadcrumbItem` is exported, the field is exported, and the build logic is localized in `HtmlViewer.Render`.
+
+---
+
+## Section 7 — Test Plan
+
+Tests live next to existing engine tests, following the `*_test.go` convention. Each row below is one `t.Run` subtest in a single `TestBreadcrumb` function.
+
+| Input | URL | Expected chain |
+|---|---|---|
+| Root page | `/` | `Breadcrumb == nil` |
+| Single segment | `/blog` | `[{Path:"/", Name:"Home"}, {Path:"/blog", Name:"blog", Title:"", Last:true}]` |
+| Multi segment, no markdown | `/blog/2026/x.html` (assuming no matching `.md`) | trailing item has `Title == ""` |
+| Multi segment, markdown ancestor | `/blog/2026/x.md` where H1 = "深入 Xun" | trailing item has `Title == "深入 Xun"`; intermediate `/blog/2026/index.md` items carry their own H1s when present |
+| Chinese URL segment | `/blog/深入探索` | `Name == "深入探索"` (raw, no transliteration) |
+| Dynamic segment | `/user/42` | trailing item has `Name == "42"`, `Last == true`, `Title == ""` |
+| Trailing slash normalization | `/blog/` (Sermux canonicalizes) | behaves identically to `/blog` |
+| Hot reload | Edit `.md` H1, refetch | new `Title` reflects new H1 (re-derives via existing content engine reload path) |
+
+Coverage for HTML escaping lives in the existing template tests; `BreadcrumbItem` fields are plain strings and `html/template` handles them automatically. No special escaping tests are needed.
+
+---
+
+## Section 8 — Compatibility
+
+This feature is fully additive:
+
+- `ViewModel` gains one field; existing three-field reads (template paths that use only `.TempData`, `.Data`, `.Content`) keep working.
+- `HtmlViewer.Render` changes shape but not signature.
+- No public API is renamed or removed.
+- No file convention is introduced or modified.
+- `WithNavigation`, `WithMetadata`, `Routing.Options.Get`, `WithViewer`, and the existing `RoutingOptions` accessors remain untouched.
+
+The change passes the AGENTS.md §20 "safe-change checklist": minimal, additive, preserves MIME/route/hot-reload semantics, no default-behavior change for sites that do not read `.Breadcrumb`.

--- a/viewer.go
+++ b/viewer.go
@@ -18,9 +18,31 @@ type Viewer interface {
 	Render(ctx *Context, data any) error
 }
 
+// BreadcrumbItem is one node in the breadcrumb chain rendered into templates.
+//
+//   - Path:  the URL prefix leading to this node, including leading slash.
+//     The root item has Path = "/".
+//   - Name:  the link label. For non-root items this is the last segment of
+//     Path verbatim (no transformation). The root item has the fixed
+//     Name "Home".
+//   - Title: hover hint, sourced from ContentView.Title (Markdown H1).
+//     Empty for non-Markdown ancestors.
+//   - Last:  true on the trailing item (current page).
+type BreadcrumbItem struct {
+	Path  string
+	Name  string
+	Title string
+	Last  bool
+}
+
 // ViewModel holds the context and associated data for rendering.
 type ViewModel struct {
 	TempData map[string]any
 	Data     any
 	Content  *ContentView // optional, populated when the route was registered from a .md file
+
+	// Breadcrumb is the ancestor chain for the current request URL, top to
+	// bottom, with the current page as the trailing element (Last == true).
+	// nil on the root path (GET /{$}). See docs/breadcrumb.md.
+	Breadcrumb []BreadcrumbItem
 }

--- a/viewer_breadcrumb_test.go
+++ b/viewer_breadcrumb_test.go
@@ -1,0 +1,434 @@
+package xun
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// buildBreadcrumb (unit tests on the helper directly)
+// =============================================================================
+
+func TestBuildBreadcrumbRoot(t *testing.T) {
+	ctx := &Context{
+		Request: httptest.NewRequest(http.MethodGet, "/", nil),
+	}
+	require.Nil(t, buildBreadcrumb(ctx))
+}
+
+func TestBuildBreadcrumbSingleSegmentNoApp(t *testing.T) {
+	ctx := &Context{
+		Request: httptest.NewRequest(http.MethodGet, "/blog", nil),
+	}
+	got := buildBreadcrumb(ctx)
+	require.Equal(t, []BreadcrumbItem{
+		{Path: "/", Name: "Home"},
+		{Path: "/blog", Name: "blog", Last: true},
+	}, got)
+}
+
+func TestBuildBreadcrumbMultiSegment(t *testing.T) {
+	app := &App{
+		contentViews: map[string]*ContentView{
+			"GET /blog/2026/x": {Slug: "blog/2026/x", Title: "深入 Xun"},
+		},
+	}
+	ctx := &Context{
+		App:     app,
+		Request: httptest.NewRequest(http.MethodGet, "/blog/2026/x", nil),
+	}
+
+	got := buildBreadcrumb(ctx)
+	require.Len(t, got, 4)
+	require.Equal(t, BreadcrumbItem{Path: "/", Name: "Home"}, got[0])
+	require.Equal(t, BreadcrumbItem{Path: "/blog", Name: "blog"}, got[1])
+	require.Equal(t, BreadcrumbItem{Path: "/blog/2026", Name: "2026"}, got[2])
+	require.Equal(t, BreadcrumbItem{
+		Path:  "/blog/2026/x",
+		Name:  "x",
+		Title: "深入 Xun",
+		Last:  true,
+	}, got[3])
+}
+
+func TestBuildBreadcrumbTitleOnlyForMarkdownAncestors(t *testing.T) {
+	app := &App{
+		contentViews: map[string]*ContentView{
+			// Only /blog/2026/x is markdown; intermediate paths are .html
+			// pages and therefore absent from contentViews.
+			"GET /blog/2026/x": {Slug: "blog/2026/x", Title: "Post Title"},
+		},
+	}
+	ctx := &Context{
+		App:     app,
+		Request: httptest.NewRequest(http.MethodGet, "/blog/2026/x", nil),
+	}
+
+	got := buildBreadcrumb(ctx)
+	for i, item := range got {
+		if i == len(got)-1 {
+			require.Equal(t, "Post Title", item.Title, "trailing item should pick up H1")
+		} else {
+			require.Empty(t, item.Title, "non-markdown ancestor %s should have empty Title", item.Path)
+		}
+	}
+}
+
+func TestBuildBreadcrumbMarkdownAncestorCarriesOwnH1(t *testing.T) {
+	app := &App{
+		contentViews: map[string]*ContentView{
+			"GET /blog":           {Slug: "blog", Title: "博客首页"},
+			"GET /blog/2026":      {Slug: "blog/2026", Title: "2026 年文章"},
+			"GET /blog/2026/x":    {Slug: "blog/2026/x", Title: "深入 Xun"},
+		},
+	}
+	ctx := &Context{
+		App:     app,
+		Request: httptest.NewRequest(http.MethodGet, "/blog/2026/x", nil),
+	}
+
+	got := buildBreadcrumb(ctx)
+	require.Len(t, got, 4)
+	require.Equal(t, "博客首页", got[1].Title)
+	require.Equal(t, "2026 年文章", got[2].Title)
+	require.Equal(t, "深入 Xun", got[3].Title)
+}
+
+func TestBuildBreadcrumbChineseSegmentIsRaw(t *testing.T) {
+	ctx := &Context{
+		Request: httptest.NewRequest(http.MethodGet, "/blog/深入探索", nil),
+	}
+	got := buildBreadcrumb(ctx)
+	require.Len(t, got, 3)
+	require.Equal(t, "深入探索", got[2].Name)
+}
+
+func TestBuildBreadcrumbDynamicSegment(t *testing.T) {
+	ctx := &Context{
+		Request: httptest.NewRequest(http.MethodGet, "/user/42", nil),
+	}
+	got := buildBreadcrumb(ctx)
+	require.Len(t, got, 3)
+	require.Equal(t, "42", got[2].Name, "dynamic segment should appear verbatim")
+	require.True(t, got[2].Last)
+	require.Empty(t, got[2].Title, "no content view registered for dynamic route")
+}
+
+func TestBuildBreadcrumbEmptyTitleIsKept(t *testing.T) {
+	// A markdown file without an H1 should still produce a chain entry, just
+	// without Title. The trailing item is still Last.
+	app := &App{
+		contentViews: map[string]*ContentView{
+			"GET /no-h1": {Slug: "no-h1", Title: ""},
+		},
+	}
+	ctx := &Context{
+		App:     app,
+		Request: httptest.NewRequest(http.MethodGet, "/no-h1", nil),
+	}
+	got := buildBreadcrumb(ctx)
+	require.Len(t, got, 2)
+	require.True(t, got[1].Last)
+	require.Empty(t, got[1].Title)
+}
+
+// =============================================================================
+// Integration: end-to-end render through HtmlViewer with real .md / .html files
+// =============================================================================
+
+func TestBreadcrumbEndToEndMarkdown(t *testing.T) {
+	fsys := fstest.MapFS{
+		"index.html": {Data: []byte(`<nav>{{range .Breadcrumb}}{{if .Last}}[{{.Name}}|{{.Title}}]{{else}}<a href="{{.Path}}">{{.Name}}</a>{{end}}{{end}}</nav>`)},
+		"blog/2026/x.md": {Data: []byte("# 深入 Xun\n\n正文.")},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys), WithContent("blog"))
+	app.Start()
+	defer app.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/blog/2026/x", nil)
+	req.Header.Set("Accept", "text/html")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	buf, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	body := string(buf)
+	require.Contains(t, body, `<a href="/">Home</a>`)
+	require.Contains(t, body, `<a href="/blog">blog</a>`)
+	require.Contains(t, body, `<a href="/blog/2026">2026</a>`)
+	require.Contains(t, body, `[x|深入 Xun]`, "trailing item should render as plain with H1 title")
+}
+
+func TestBreadcrumbEndToEndHtmlPage(t *testing.T) {
+	fsys := fstest.MapFS{
+		"pages/blog/index.html": {Data: []byte(`<nav>{{range .Breadcrumb}}{{if .Last}}[{{.Name}}|{{.Title}}]{{else}}<a href="{{.Path}}">{{.Name}}</a>{{end}}{{end}}</nav>`)},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys))
+	app.Start()
+	defer app.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/blog", nil)
+	req.Header.Set("Accept", "text/html")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	buf, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	body := string(buf)
+	require.Contains(t, body, `<a href="/">Home</a>`)
+	require.Contains(t, body, `[blog|]`, "trailing item has no Title because no .md ancestor")
+}
+
+func TestBreadcrumbRootHasNoChain(t *testing.T) {
+	fsys := fstest.MapFS{
+		"pages/index.html": {Data: []byte(`{{if .Breadcrumb}}HAS{{else}}NONE{{end}}`)},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys))
+	app.Start()
+	defer app.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/", nil)
+	req.Header.Set("Accept", "text/html")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	buf, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	require.Equal(t, "NONE", string(buf))
+}
+
+// =============================================================================
+// Trailing-slash normalization
+// =============================================================================
+
+func TestBuildBreadcrumbTrailingSlash(t *testing.T) {
+	withSlash := buildBreadcrumb(&Context{
+		Request: httptest.NewRequest(http.MethodGet, "/blog/", nil),
+	})
+	withoutSlash := buildBreadcrumb(&Context{
+		Request: httptest.NewRequest(http.MethodGet, "/blog", nil),
+	})
+	require.Equal(t, withSlash, withoutSlash)
+}
+
+// =============================================================================
+// Robustness: Build with nil App (defensive)
+// =============================================================================
+
+func TestBuildBreadcrumbNilApp(t *testing.T) {
+	ctx := &Context{
+		Request: httptest.NewRequest(http.MethodGet, "/blog/2026/x", nil),
+	}
+	got := buildBreadcrumb(ctx)
+	require.Len(t, got, 4)
+	for i, item := range got {
+		if i == len(got)-1 {
+			require.True(t, item.Last)
+		}
+		require.Empty(t, item.Title, "without App, Title stays empty")
+	}
+}
+
+func TestBuildBreadcrumbNilRequest(t *testing.T) {
+	require.Nil(t, buildBreadcrumb(&Context{}))
+}
+
+// =============================================================================
+// ViewModel field exists with the documented zero value
+// =============================================================================
+
+func TestViewModelBreadcrumbZeroValue(t *testing.T) {
+	var vm ViewModel
+	require.Nil(t, vm.Breadcrumb)
+	// Sanity: TempData/Data/Content also default to zero values.
+	require.Nil(t, vm.TempData)
+	require.Nil(t, vm.Data)
+	require.Nil(t, vm.Content)
+}
+
+// =============================================================================
+// Last flag is set exactly once
+// =============================================================================
+
+func TestBuildBreadcrumbExactlyOneLast(t *testing.T) {
+	ctx := &Context{
+		Request: httptest.NewRequest(http.MethodGet, "/a/b/c/d", nil),
+	}
+	got := buildBreadcrumb(ctx)
+	count := 0
+	for _, item := range got {
+		if item.Last {
+			count++
+		}
+	}
+	require.Equal(t, 1, count)
+	require.True(t, got[len(got)-1].Last)
+}
+
+// =============================================================================
+// Output stability: deterministic order, no surprises in serialized form
+// =============================================================================
+
+func TestBuildBreadcrumbOrderTopToBottom(t *testing.T) {
+	ctx := &Context{
+		Request: httptest.NewRequest(http.MethodGet, "/a/b/c", nil),
+	}
+	got := buildBreadcrumb(ctx)
+	require.Equal(t, "/", got[0].Path)
+	require.Equal(t, "/a", got[1].Path)
+	require.Equal(t, "/a/b", got[2].Path)
+	require.Equal(t, "/a/b/c", got[3].Path)
+	// Root Name is the fixed "Home" string; subsequent Names are raw segments.
+	require.Equal(t, []string{"Home", "a", "b", "c"}, []string{
+		got[0].Name, got[1].Name, got[2].Name, got[3].Name,
+	})
+}
+
+// =============================================================================
+// Sanity: ensure no off-by-one when URL has only the root segment
+// =============================================================================
+
+func TestBuildBreadcrumbSingleSegmentIsLast(t *testing.T) {
+	got := buildBreadcrumb(&Context{
+		Request: httptest.NewRequest(http.MethodGet, "/only", nil),
+	})
+	require.Len(t, got, 2)
+	require.False(t, got[0].Last)
+	require.True(t, got[1].Last)
+	require.Equal(t, "only", got[1].Name)
+}
+
+// =============================================================================
+// Concurrent access: buildBreadcrumb is a pure function (no locks); smoke test
+// confirms it composes safely under concurrent render.
+// =============================================================================
+
+func TestBuildBreadcrumbConcurrentSafe(t *testing.T) {
+	app := &App{
+		contentViews: map[string]*ContentView{
+			"GET /x": {Title: "X"},
+		},
+	}
+	const n = 50
+	errs := make(chan string, n)
+	for i := 0; i < n; i++ {
+		go func() {
+			got := buildBreadcrumb(&Context{
+				App:     app,
+				Request: httptest.NewRequest(http.MethodGet, "/x", nil),
+			})
+			if len(got) != 2 || got[1].Title != "X" || !got[1].Last {
+				errs <- "wrong result"
+				return
+			}
+			errs <- ""
+		}()
+	}
+	for i := 0; i < n; i++ {
+		if msg := <-errs; msg != "" {
+			t.Fatal(msg)
+		}
+	}
+}
+
+// =============================================================================
+// Real-world URL with %-encoded segments: framework returns decoded Path; ensure
+// we handle whatever http.Request.URL.Path gives us.
+// =============================================================================
+
+func TestBuildBreadcrumbDecodedPath(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/blog/hello%20world", nil)
+	got := buildBreadcrumb(&Context{Request: req})
+	require.Len(t, got, 3)
+	require.Equal(t, "hello world", got[2].Name, "URL.Path is already decoded by net/http")
+	require.True(t, got[2].Last)
+	require.Equal(t, "/blog/hello world", req.URL.Path, "sanity: net/http stores decoded form")
+}
+
+// =============================================================================
+// Dynamic .md routes: contentViews is keyed by Routing.Pattern (with braces),
+// not by the concrete URL. The current-page lookup must use Routing.Pattern
+// or the H1 is lost.
+// =============================================================================
+
+func TestBuildBreadcrumbDynamicMarkdownCurrentPage(t *testing.T) {
+	app := &App{
+		contentViews: map[string]*ContentView{
+			// Registered under the braced pattern, as the framework does.
+			"GET /blog/{slug}": {Slug: "blog/{slug}", Title: "User Profile"},
+		},
+	}
+	ctx := &Context{
+		App:     app,
+		Request: httptest.NewRequest(http.MethodGet, "/blog/foo", nil),
+		Routing: Routing{Pattern: "GET /blog/{slug}"},
+	}
+
+	got := buildBreadcrumb(ctx)
+	require.Len(t, got, 3)
+	require.Equal(t, "foo", got[2].Name, "Name is the concrete URL segment")
+	require.True(t, got[2].Last)
+	require.Equal(t, "User Profile", got[2].Title, "Title must use Routing.Pattern to match braced contentViews key")
+}
+
+func TestBuildBreadcrumbDynamicMarkdownAncestorUntouched(t *testing.T) {
+	// Ancestor items must still walk URL.Path; only the current page uses
+	// Routing.Pattern. The framework registers content/blog/index.md as
+	// "GET /blog/index" (the literal /index segment is preserved), so a
+	// request to /blog/index/foo walks the prefix /blog/index and finds it.
+	app := &App{
+		contentViews: map[string]*ContentView{
+			"GET /blog/index":  {Title: "Blog Index"},
+			"GET /blog/{slug}": {Title: "Post Title"},
+		},
+	}
+	ctx := &Context{
+		App:     app,
+		Request: httptest.NewRequest(http.MethodGet, "/blog/index/foo", nil),
+		Routing: Routing{Pattern: "GET /blog/{slug}"},
+	}
+
+	got := buildBreadcrumb(ctx)
+	require.Len(t, got, 4)
+	require.Equal(t, "Blog Index", got[2].Title, "ancestor /blog/index resolves via URL-derived pattern")
+	require.Equal(t, "Post Title", got[3].Title, "current page /blog/index/foo resolves via Routing.Pattern")
+}
+
+func TestBuildBreadcrumbDynamicMarkdownEmptyRoutingPatternFallsBack(t *testing.T) {
+	// Defensive: if Routing.Pattern is empty for some reason, fall back to
+	// URL-derived pattern (Title stays empty for dynamic .md, but no panic).
+	app := &App{
+		contentViews: map[string]*ContentView{
+			"GET /blog/{slug}": {Title: "Post Title"},
+		},
+	}
+	ctx := &Context{
+		App:     app,
+		Request: httptest.NewRequest(http.MethodGet, "/blog/foo", nil),
+		// Routing.Pattern intentionally empty.
+	}
+
+	got := buildBreadcrumb(ctx)
+	require.Empty(t, got[2].Title, "no Routing.Pattern → no Title for dynamic .md (graceful)")
+	require.True(t, got[2].Last)
+}

--- a/viewer_html.go
+++ b/viewer_html.go
@@ -2,6 +2,7 @@ package xun
 
 import (
 	"net/http"
+	"strings"
 )
 
 // HtmlViewer is a viewer that renders a html template.
@@ -39,6 +40,7 @@ func (v *HtmlViewer) Render(ctx *Context, data any) error { // skipcq: RVV-B0012
 			if cv := ctx.App.lookupContent(ctx.Routing.Pattern); cv != nil {
 				vm.Content = cv
 			}
+			vm.Breadcrumb = buildBreadcrumb(ctx)
 		}
 
 		err = v.template.Execute(buf, vm)
@@ -48,4 +50,55 @@ func (v *HtmlViewer) Render(ctx *Context, data any) error { // skipcq: RVV-B0012
 		_, err = buf.WriteTo(ctx.Response)
 	}
 	return err
+}
+
+// buildBreadcrumb walks the request URL and produces the ancestor chain for
+// templates. See docs/breadcrumb.md §2 for the full algorithm and rationale.
+//
+// The returned slice is ordered top-to-bottom: items[0] is the root
+// ("Home"), items[len-1] is the current page with Last == true. nil on the
+// root path (GET /{$}).
+func buildBreadcrumb(ctx *Context) []BreadcrumbItem {
+	if ctx.Request == nil || ctx.Request.URL == nil {
+		return nil
+	}
+
+	path := strings.Trim(ctx.Request.URL.Path, "/")
+	if path == "" {
+		return nil
+	}
+
+	segs := strings.Split(path, "/")
+	items := make([]BreadcrumbItem, 0, len(segs)+1)
+
+	items = append(items, BreadcrumbItem{Path: "/", Name: "Home"})
+
+	for i, seg := range segs {
+		prefix := "/" + strings.Join(segs[:i+1], "/")
+		// Ancestor items are looked up by URL-derived pattern because the
+		// ancestor's content view, if any, was registered against the
+		// concrete URL. The current page's Routing.Pattern may contain
+		// braces for dynamic .md routes (e.g. "GET /blog/{slug}") and
+		// must be preferred so dynamic .md ancestors keep their H1.
+		pattern := "GET " + prefix
+		if i == len(segs)-1 && ctx.Routing.Pattern != "" {
+			pattern = ctx.Routing.Pattern
+		}
+
+		title := ""
+		if ctx.App != nil {
+			if cv := ctx.App.lookupContent(pattern); cv != nil && cv.Title != "" {
+				title = cv.Title
+			}
+		}
+
+		items = append(items, BreadcrumbItem{
+			Path:  prefix,
+			Name:  seg,
+			Title: title,
+		})
+	}
+
+	items[len(items)-1].Last = true
+	return items
 }


### PR DESCRIPTION
## Why

Today an HTML template can render the current page (via `vm.Content`)
but has no structured way to render the path that led to it. Sites that
nest content — blogs under `/blog/<year>/<slug>`, docs under
`/docs/<section>/<page>`, etc. — want a breadcrumb trail, and currently
each app has to recompute the ancestor walk itself, glue the H1 from the
markdown index, and pass it through a custom handler signature.

This change makes that walk a property of the `ViewModel` itself, so any
template gets a consistent, top-to-bottom ancestor chain without
per-route boilerplate. It is deliberately a **data-only** addition —
`ViewModel.Breadcrumb []BreadcrumbItem` — with no template function, no
JSON-LD helper, no new option, and no metadata file convention. The
sibling design doc (`docs/breadcrumb.md`) makes that boundary explicit so
future features don't pile presentation concerns onto this slice.

## What changed

`HtmlViewer.Render` now populates a new `Breadcrumb []BreadcrumbItem`
field on `ViewModel` immediately after the existing `vm.Content` lookup
and before `template.Execute`. For `GET /{$}` the field stays `nil`;
otherwise it is `[Home, ancestor₁, …, current]` ordered top-to-bottom,
with `Last == true` set on the trailing element. `Name` is the URL
segment verbatim, `Title` is the Markdown H1 from `ContentView` (empty
for non-markdown ancestors), and `Path` is the prefix that links back
to that node.

The change is additive: `ViewModel`'s existing `TempData`, `Data`,
`Content` fields are untouched, and templates that do not reference
`.Breadcrumb` see no behavioural difference.

## Diff overview

- `viewer.go` — adds `BreadcrumbItem` (Path/Name/Title/Last) plus the
  `Breadcrumb []BreadcrumbItem` field on `ViewModel` with a doc comment
  describing the top-to-bottom ordering, the trailing-current-page
  invariant, and the nil-on-root contract.
- `viewer_html.go` — imports `strings`; calls `buildBreadcrumb(ctx)`
  right after the `vm.Content` lookup in `Render`; defines
  `buildBreadcrumb` which trims the request path, short-circuits on the
  root, seeds a fixed `"Home"` root item, then walks the URL segments
  emitting one item per prefix. For each prefix it looks up the matching
  `ContentView` via `App.lookupContent` to populate `Title`, and for the
  trailing segment it prefers `ctx.Routing.Pattern` over the URL-derived
  pattern so dynamic `.md` routes (e.g. `GET /blog/{slug}`) keep their
  H1. Sets `Last` on the last item before returning.
- `viewer_breadcrumb_test.go` (new, 434 lines) — covers the helper
  directly and through `HtmlViewer.Render`. Cases include: root path
  returns `nil`; single-segment URLs with no app; multi-segment URLs
  with mixed markdown / HTML ancestors (Title only on the markdown
  ones); dynamic-pattern routes where `Routing.Pattern` differs from
  the URL-derived prefix; missing/non-existent request URLs; empty
  `ContentView.Title`; and end-to-end template execution asserting the
  rendered HTML contains the expected `<a>` / `<span>` split keyed off
  `Last`.
- `docs/breadcrumb.md` (new, 232 lines) — design document that
  codifies the "data only" principle, the `Name` vs `Title` split, the
  root-returns-nil contract, the construction algorithm with rationale
  (including why `Routing.Pattern` is preferred for the trailing
  segment), and the alternative-API table covering things explicitly
  *not* added (template funcs, JSON-LD generator, pageMeta map,
  `WithBreadcrumb` toggle).

## Test evidence

- `viewer_breadcrumb_test.go` is new — 434 lines covering `buildBreadcrumb`
  in isolation and through `HtmlViewer.Render`, including the dynamic
  pattern case (`/blog/{slug}`) that is the trickiest path. The full file
  has not been executed in this session (`go test` was not run here);
  reviewers should run `go test ./...` locally to confirm.
- No existing tests were modified; the change is purely additive on the
  `ViewModel` surface, so regressions in unrelated templates would only
  surface via compilation, which the additive field cannot cause.
- Documentation-only companion: `docs/breadcrumb.md` mirrors the design
  in code comments on `BreadcrumbItem` and `ViewModel.Breadcrumb` so the
  godoc and the long-form doc stay aligned.