### PR TITLE
refactor(content): split template and page conventions with .tpl/.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ go get github.com/yaitoo/xun@latest
 - `layouts`: A layout is shared between multiple pages/views
 - `pages`: A public page view that will create public page routing automatically.
 - `text`: An internal text view that can be referenced in `context.View` to render with a data model.
-- `content`: A Markdown-driven page tree. Every `.md` file auto-registers as `GET /<slug>`; paired `.html` files act as the rendering template and use the same `layouts/` directory as everything else.
+- `content`: A Markdown-driven page tree. Every `.md` file auto-registers as `GET /<slug>`; paired `.tpl` files act as the bubble-up template (never registered as a route) and use the same `layouts/` directory as everything else. `.html` files in `content/` are independent page routes.
 
 **NOTE: All html files(component,layout, view and page) will be parsed by [html/template](https://pkg.go.dev/html/template). You can feel free to use all built-in [Actions,Pipelines and Functions](https://pkg.go.dev/text/template), and your custom functions that is registered in `HtmlViewEngine`.**
 
@@ -213,7 +213,14 @@ A text view is UI that is referenced in `context.View` to render the view with a
 
 
 ### Content
-The Content engine turns Markdown files into pages without introducing a new `Viewer` or a second template engine. Drop a `.md` file into `content/` and it auto-registers as `GET /<slug>`; drop an `.html` next to it (or any ancestor `index.html`) to control how the rendered Markdown is wrapped.
+The Content engine turns Markdown files into pages without introducing a new `Viewer` or a second template engine. Drop a `.md` file into `content/` and it auto-registers as `GET /<slug>`; drop a `.tpl` next to it (or any ancestor `index.tpl`) to control how the rendered Markdown is wrapped.
+
+`.html` and `.tpl` inside `content/` have distinct roles:
+
+- `.tpl` — bubble-up template only. Loaded into the template graph; never registered as a route.
+- `.html` — page route only. Registered as a route; never consulted during bubble-up.
+
+This is what lets a directory such as `content/blog/` hold both `index.tpl` (wrapping template) and `index.md` (real Markdown page) without conflict.
 
 #### Directory layout
 ```
@@ -222,18 +229,19 @@ The Content engine turns Markdown files into pages without introducing a new `Vi
     │   └── site.html
     └── content
         ├── hello.md           ← GET /hello
-        ├── hello.html         ← optional, dedicated template for /hello
+        ├── hello.tpl          ← optional, dedicated template for /hello
         └── 2026
-            ├── index.html     ← bubble-up target
+            ├── index.tpl      ← bubble-up target (not a route)
+            ├── index.md       ← optional, directory-level page: GET /2026/
             └── deeper.md      ← GET /2026/deeper
 ```
 
-For each `.md` file, the engine looks for an HTML template in this order:
+For each `.md` file, the engine looks for a bubble-up template in this order:
 
-1. `content/<slug>.html`
-2. `content/<dir>/index.html`
-3. any ancestor `index.html`
-4. the root `index.html`
+1. `content/<slug>.tpl`
+2. `content/<dir>/index.tpl`
+3. any ancestor `index.tpl`
+4. the root `index.tpl`
 
 The first match is the template; it uses the same `<!--layout:NAME-->` mechanism as every other page, so layouts are shared across content and non-content pages.
 
@@ -252,9 +260,9 @@ task lists, fenced code, autolinks.
 ```
 
 #### Rendering the page in a template
-A request to `/hello` lands on `content/hello.html` (or whichever template the bubble-up rule picked). Inside the template, the parsed Markdown is exposed as `.Content`:
+A request to `/hello` lands on `content/hello.tpl` (or whichever template the bubble-up rule picked). Inside the template, the parsed Markdown is exposed as `.Content`:
 
-> content/hello.html
+> content/hello.tpl
 ```html
 <!--layout:site-->
 {{ define "content" }}
@@ -299,7 +307,7 @@ defer app.Close()
 http.ListenAndServe(":80", http.DefaultServeMux)
 ```
 
-With `content/hello.md` and `content/hello.html` in place, `curl http://localhost/hello` returns the rendered page.
+With `content/hello.md` and `content/hello.tpl` in place, `curl http://localhost/hello` returns the rendered page.
 
 
 

--- a/content_test.go
+++ b/content_test.go
@@ -1,6 +1,7 @@
 package xun
 
 import (
+	"bytes"
 	"html/template"
 	"io"
 	"io/fs"
@@ -261,9 +262,9 @@ func TestContentEngineEndToEnd(t *testing.T) {
 
 More content.`),
 		},
-		"content/2026/index.html": {Data: []byte(`<!--layout:site-->
+		"content/2026/index.tpl": {Data: []byte(`<!--layout:site-->
 {{define "content"}}<article><h1>{{.Content.Title}}</h1><p>{{.Content.Description}}</p>{{.Content.Body}}</article>{{end}}`)},
-		"content/index.html":       {Data: []byte(`<!--layout:site-->
+		"content/index.tpl":       {Data: []byte(`<!--layout:site-->
 {{define "content"}}<h1>{{.Content.Title}}</h1>{{.Content.Body}}{{end}}`)},
 	}
 
@@ -296,7 +297,7 @@ More content.`),
 	body = string(buf)
 	require.Contains(t, body, "Deeper Post")             // title
 	require.Contains(t, body, "A lede paragraph.")       // description (blockquote)
-	require.Contains(t, body, "<article>")               // bubble-up to 2026/index.html
+	require.Contains(t, body, "<article>")               // bubble-up to 2026/index.tpl
 	require.Contains(t, body, "<h2>Section</h2>")         // markdown h2 in body
 	require.Contains(t, body, "More content.")            // markdown paragraph
 }
@@ -305,7 +306,7 @@ func TestContentEngineBubbleUpToRoot(t *testing.T) {
 	fsys := fstest.MapFS{
 		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
 		"content/orphan.md": {Data: []byte("# Orphan")},
-		"index.html": {Data: []byte(`<!--layout:site-->
+		"index.tpl": {Data: []byte(`<!--layout:site-->
 {{define "content"}}<main>{{.Content.Title}}{{.Content.Body}}</main>{{end}}`)},
 	}
 
@@ -328,7 +329,7 @@ func TestContentEngineBubbleUpToRoot(t *testing.T) {
 }
 
 func TestContentEngineNoTemplate(t *testing.T) {
-	// No index.html anywhere → warning logged, route not registered.
+	// No index.tpl anywhere → warning logged, route not registered.
 	fsys := fstest.MapFS{
 		"content/orphan.md": {Data: []byte("# Orphan")},
 	}
@@ -375,40 +376,216 @@ func TestContentEngineNonContentRouteHasNilContent(t *testing.T) {
 	require.NotContains(t, body, "BAD") // Content was nil → guard skipped
 }
 
+// A bare .tpl template in content/ must NOT register a route. Only the
+// template is loaded into the template graph.
+func TestContentTemplateNotRegistered(t *testing.T) {
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"content/blog/index.tpl": {Data: []byte(`<!--layout:site-->
+{{define "content"}}<p>template only</p>{{end}}`)},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys))
+	app.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/content/blog", nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode,
+		".tpl must not register a route; only sibling .md does")
+}
+
+// .tpl (template) and .md (page) coexist in the same directory. The
+// template wraps sibling .md posts; the .md file is itself a real page
+// at the directory route.
+func TestContentTemplateAndPageCoexist(t *testing.T) {
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"content/blog/index.tpl": {Data: []byte(`<!--layout:site-->
+{{define "content"}}<article><h1>{{.Content.Title}}</h1><div>{{.Content.Body}}</div></article>{{end}}`)},
+		"content/blog/index.md": {Data: []byte("# 博客首页\n\n这里是博客根页内容。")},
+		"content/blog/post.md": {Data: []byte("# 第一篇\n\n文章正文。")},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys))
+	app.Close()
+
+	// Directory-level page: GET /content/blog/index renders index.md wrapped by index.tpl.
+	req, _ := http.NewRequest("GET", srv.URL+"/content/blog/index", nil)
+	req.Header.Set("Accept", "text/html")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	buf, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	body := string(buf)
+	require.Contains(t, body, "<article>")
+	require.Contains(t, body, "博客首页")
+	require.Contains(t, body, "这里是博客根页内容")
+
+	// Sibling post: GET /content/blog/post uses the same template.
+	req, _ = http.NewRequest("GET", srv.URL+"/content/blog/post", nil)
+	req.Header.Set("Accept", "text/html")
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+	buf, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	body = string(buf)
+	require.Contains(t, body, "<article>")
+	require.Contains(t, body, "第一篇")
+
+	// Both routes should have their own ContentView so the breadcrumb
+	// chain can carry H1s for the ancestor directory.
+	require.Contains(t, app.contentViews, "GET /content/blog/index")
+	require.Contains(t, app.contentViews, "GET /content/blog/post")
+	require.Equal(t, "博客首页", app.contentViews["GET /content/blog/index"].Title)
+}
+
+// .html in content/ is a page route only — it must NOT be picked up by
+// bubbleUp even if it sits next to sibling .md files.
+func TestContentHtmlNotBubbleUp(t *testing.T) {
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"content/blog/foo.md": {Data: []byte("# Foo")},
+		"content/blog/index.html": {Data: []byte(`<!--layout:site-->
+{{define "content"}}<p>standalone html page, not a template</p>{{end}}`)},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys))
+	app.Close()
+
+	// /blog is registered as a page route via the .html file (the
+	// content/ prefix is stripped because loadContentPage registers
+	// the page from the in-content relative path).
+	req, _ := http.NewRequest("GET", srv.URL+"/blog", nil)
+	req.Header.Set("Accept", "text/html")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	buf, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.Contains(t, string(buf), "standalone html page")
+
+	// /content/blog/foo has no bubble-up template → route not registered → 404.
+	req, _ = http.NewRequest("GET", srv.URL+"/content/blog/foo", nil)
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode,
+		".html in content/ is a page, not a bubble-up template")
+}
+
+// index.tpl (bubble-up template) and index.html (standalone page) must
+// coexist in the same directory. They are two distinct templates with
+// distinct roles — the template key must NOT collide.
+func TestContentTplAndHtmlCoexistInSameDir(t *testing.T) {
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"content/blog/index.tpl": {Data: []byte(`<!--layout:site-->
+{{define "content"}}<article>WRAP {{.Content.Body}}</article>{{end}}`)},
+		"content/blog/index.html": {Data: []byte(`<!--layout:site-->
+{{define "content"}}<p>standalone html page</p>{{end}}`)},
+		"content/blog/post.md": {Data: []byte("# Post\n\nBody text")},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys))
+	app.Close()
+
+	// Both templates must be cached under distinct keys. The bug being
+	// guarded against: stripping the extension produced identical keys
+	// ("content/blog/index") for both files, so whichever was walked
+	// last would silently overwrite the other.
+	var ve *HtmlViewEngine
+	for _, e := range app.engines {
+		if hve, ok := e.(*HtmlViewEngine); ok {
+			ve = hve
+			break
+		}
+	}
+	require.NotNil(t, ve)
+	require.Contains(t, ve.templates, "content/blog/index.tpl",
+		"index.tpl must be loaded as a separate template")
+	require.Contains(t, ve.templates, "content/blog/index.html",
+		"index.html must be loaded as a separate template")
+	tplT := ve.templates["content/blog/index.tpl"]
+	tplH := ve.templates["content/blog/index.html"]
+	require.NotSame(t, tplT, tplH,
+		"the two templates must NOT share the same *HtmlTemplate instance")
+
+	// /blog is the standalone .html page.
+	req, _ := http.NewRequest("GET", srv.URL+"/blog", nil)
+	req.Header.Set("Accept", "text/html")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	buf, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.Contains(t, string(buf), "standalone html page")
+
+	// /content/blog/post is the .md sibling, wrapped by the .tpl template
+	// (NOT the .html page). If the keys collided, the post would render
+	// the standalone .html instead of the wrapping .tpl.
+	req, _ = http.NewRequest("GET", srv.URL+"/content/blog/post", nil)
+	req.Header.Set("Accept", "text/html")
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+	buf, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	body := string(buf)
+	require.Contains(t, body, "WRAP", "post must be wrapped by index.tpl")
+	require.Contains(t, body, "Body text")
+	require.NotContains(t, body, "standalone html page",
+		"post must NOT be rendered through the index.html page template")
+}
+
 // =============================================================================
 // bubbleUp unit
 // =============================================================================
 
 func TestBubbleUpSpecific(t *testing.T) {
 	fsys := fstest.MapFS{
-		"content/2026/deeper.html": {Data: []byte(`<p>specific</p>`)},
+		"content/2026/deeper.tpl": {Data: []byte(`<p>specific</p>`)},
 	}
 	ve := &HtmlViewEngine{fsys: fsys, contentDirs: []string{"content"}}
-	require.Equal(t, "content/2026/deeper.html", ve.bubbleUp("content/2026/deeper.md"))
+	require.Equal(t, "content/2026/deeper.tpl", ve.bubbleUp("content/2026/deeper.md"))
 }
 
 func TestBubbleUpToIndex(t *testing.T) {
 	fsys := fstest.MapFS{
-		"content/2026/index.html": {Data: []byte(`<p>index</p>`)},
+		"content/2026/index.tpl": {Data: []byte(`<p>index</p>`)},
 	}
 	ve := &HtmlViewEngine{fsys: fsys, contentDirs: []string{"content"}}
-	require.Equal(t, "content/2026/index.html", ve.bubbleUp("content/2026/deeper.md"))
+	require.Equal(t, "content/2026/index.tpl", ve.bubbleUp("content/2026/deeper.md"))
 }
 
 func TestBubbleUpToContentIndex(t *testing.T) {
 	fsys := fstest.MapFS{
-		"content/index.html": {Data: []byte(`<p>index</p>`)},
+		"content/index.tpl": {Data: []byte(`<p>index</p>`)},
 	}
 	ve := &HtmlViewEngine{fsys: fsys, contentDirs: []string{"content"}}
-	require.Equal(t, "content/index.html", ve.bubbleUp("content/anything.md"))
+	require.Equal(t, "content/index.tpl", ve.bubbleUp("content/anything.md"))
 }
 
 func TestBubbleUpToRootIndex(t *testing.T) {
 	fsys := fstest.MapFS{
-		"index.html": {Data: []byte(`<p>root</p>`)},
+		"index.tpl": {Data: []byte(`<p>root</p>`)},
 	}
 	ve := &HtmlViewEngine{fsys: fsys, contentDirs: []string{"content"}}
-	require.Equal(t, "index.html", ve.bubbleUp("content/anything.md"))
+	require.Equal(t, "index.tpl", ve.bubbleUp("content/anything.md"))
 }
 
 func TestBubbleUpNotFound(t *testing.T) {
@@ -424,7 +601,7 @@ func TestBubbleUpNotFound(t *testing.T) {
 func TestWithContentSingle(t *testing.T) {
 	fsys := fstest.MapFS{
 		"docs/post.md": {Data: []byte("# Hello")},
-		"index.html":   {Data: []byte(`<html>{{.Content.Title}}</html>`)},
+		"index.tpl":    {Data: []byte(`<html>{{.Content.Title}}</html>`)},
 	}
 	mux := http.NewServeMux()
 	srv := httptest.NewServer(mux)
@@ -449,8 +626,8 @@ func TestWithContentMultiple(t *testing.T) {
 		"blog/post.md":      {Data: []byte("# Blog Post")},
 		"docs/api/intro.md": {Data: []byte("# Intro")},
 		"kb/123.md":         {Data: []byte("# KB Article")},
-		"index.html":        {Data: []byte(`<html>{{.Content.Title}}</html>`)},
-		"blog/index.html":   {Data: []byte(`<html>blog: {{.Content.Title}}</html>`)},
+		"index.tpl":         {Data: []byte(`<html>{{.Content.Title}}</html>`)},
+		"blog/index.tpl":    {Data: []byte(`<html>blog: {{.Content.Title}}</html>`)},
 	}
 	mux := http.NewServeMux()
 	srv := httptest.NewServer(mux)
@@ -484,7 +661,7 @@ func TestWithContentAccumulates(t *testing.T) {
 	fsys := fstest.MapFS{
 		"blog/a.md": {Data: []byte("# A")},
 		"docs/b.md": {Data: []byte("# B")},
-		"index.html": {Data: []byte(`<html>{{.Content.Title}}</html>`)},
+		"index.tpl": {Data: []byte(`<html>{{.Content.Title}}</html>`)},
 	}
 	mux := http.NewServeMux()
 	srv := httptest.NewServer(mux)
@@ -500,7 +677,7 @@ func TestWithContentAccumulates(t *testing.T) {
 func TestWithContentEmptyDisables(t *testing.T) {
 	fsys := fstest.MapFS{
 		"content/post.md": {Data: []byte("# Hello")},
-		"index.html":      {Data: []byte(`<html>{{.Content.Title}}</html>`)},
+		"index.tpl":       {Data: []byte(`<html>{{.Content.Title}}</html>`)},
 	}
 	mux := http.NewServeMux()
 	srv := httptest.NewServer(mux)
@@ -521,7 +698,7 @@ func TestWithContentEmptyDisables(t *testing.T) {
 func TestWithContentRenderer(t *testing.T) {
 	fsys := fstest.MapFS{
 		"content/post.md": {Data: []byte("# Hello")},
-		"index.html":      {Data: []byte(`<html>{{.Content.Body}}</html>`)},
+		"index.tpl":       {Data: []byte(`<html>{{.Content.Body}}</html>`)},
 	}
 	mux := http.NewServeMux()
 	srv := httptest.NewServer(mux)
@@ -549,7 +726,7 @@ func TestWithContentRenderer(t *testing.T) {
 func TestWithContentMeta(t *testing.T) {
 	fsys := fstest.MapFS{
 		"content/post.md": {Data: []byte("# Whatever")},
-		"index.html":      {Data: []byte(`<html><h1>{{.Content.Title}}</h1></html>`)},
+		"index.tpl":       {Data: []byte(`<html><h1>{{.Content.Title}}</h1></html>`)},
 	}
 	mux := http.NewServeMux()
 	srv := httptest.NewServer(mux)
@@ -587,7 +764,7 @@ func TestWithContentMeta(t *testing.T) {
 func TestFileChangedContentRemove(t *testing.T) {
 	fsys := fstest.MapFS{
 		"content/post.md": {Data: []byte("# Hello")},
-		"index.html":      {Data: []byte(`<html>{{.Content.Title}}</html>`)},
+		"index.tpl":       {Data: []byte(`<html>{{.Content.Title}}</html>`)},
 	}
 	ve := &HtmlViewEngine{fsys: fsys, contentDirs: []string{"content"}}
 	ve.templates = map[string]*HtmlTemplate{}
@@ -606,7 +783,7 @@ func TestFileChangedContentRemove(t *testing.T) {
 func TestFileChangedContentWrite(t *testing.T) {
 	fsys := fstest.MapFS{
 		"content/post.md": {Data: []byte("# Updated Title")},
-		"index.html":      {Data: []byte(`<html>{{.Content.Title}}</html>`)},
+		"index.tpl":       {Data: []byte(`<html>{{.Content.Title}}</html>`)},
 	}
 	mux := http.NewServeMux()
 	app := &App{
@@ -637,6 +814,120 @@ func TestFileChangedContentOutsideDirIgnored(t *testing.T) {
 	require.Empty(t, app.contentViews)
 }
 
+// .tpl Write on an already-loaded template must ReLoad in place so the
+// existing HtmlViewer (referencing the same *HtmlTemplate) sees the
+// change, instead of being shadowed by a freshly-allocated instance.
+func TestFileChangedTplWriteReloadsInPlace(t *testing.T) {
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"content/blog/index.tpl": {
+			Data: []byte(`<!--layout:site-->
+{{define "content"}}<p>v1</p>{{end}}`),
+		},
+		"content/blog/post.md": {Data: []byte("# Post")},
+	}
+
+	mux := http.NewServeMux()
+	app := &App{
+		mux:          mux,
+		routes:       map[string]*Routing{},
+		viewers:      map[string]Viewer{},
+		contentViews: map[string]*ContentView{},
+		funcMap:      template.FuncMap{},
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	ve := &HtmlViewEngine{fsys: fsys, contentDirs: []string{"content"}, app: app}
+	ve.templates = map[string]*HtmlTemplate{}
+	ve.md = newContentRenderer()
+	ve.Load(fsys, app)
+
+	// Capture the exact *HtmlTemplate instance that the route uses.
+	original, ok := ve.templates["content/blog/index.tpl"]
+	require.True(t, ok)
+	post, ok := app.routes["GET /content/blog/post"]
+	require.True(t, ok)
+	viewer, ok := post.Viewers[0].(*HtmlViewer)
+	require.True(t, ok)
+	require.Same(t, original, viewer.template,
+		"route viewer must reference the cached *HtmlTemplate")
+
+	// Mutate the file on disk and fire Write.
+	fsys["content/blog/index.tpl"] = &fstest.MapFile{
+		Data: []byte(`<!--layout:site-->
+{{define "content"}}<p>v2</p>{{end}}`),
+	}
+	require.NoError(t, ve.FileChanged(fsys, app, fsnotifyWriteEvent("content/blog/index.tpl")))
+
+	// Same instance, new content.
+	require.Same(t, original, ve.templates["content/blog/index.tpl"],
+		"Write must Reload in place, not allocate a new instance")
+	require.Same(t, original, viewer.template,
+		"existing HtmlViewer must keep seeing the same *HtmlTemplate")
+
+	buf := &bytes.Buffer{}
+	require.NoError(t, viewer.template.Execute(buf, ViewModel{Content: &ContentView{Title: "Post"}}))
+	require.Contains(t, buf.String(), "v2",
+		"post route must render the updated template")
+}
+
+// .tpl Remove must drop the cached entry so subsequent loadContentFile
+// calls do not point at a stale template.
+func TestFileChangedTplRemoveClearsCache(t *testing.T) {
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"content/blog/index.tpl": {
+			Data: []byte(`<!--layout:site-->
+{{define "content"}}<p>v1</p>{{end}}`),
+		},
+	}
+	app := &App{
+		mux:          http.NewServeMux(),
+		routes:       map[string]*Routing{},
+		viewers:      map[string]Viewer{},
+		contentViews: map[string]*ContentView{},
+		funcMap:      template.FuncMap{},
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	ve := &HtmlViewEngine{fsys: fsys, contentDirs: []string{"content"}, app: app}
+	ve.templates = map[string]*HtmlTemplate{}
+	ve.md = newContentRenderer()
+	ve.Load(fsys, app)
+
+	require.Contains(t, ve.templates, "content/blog/index.tpl")
+
+	require.NoError(t, ve.FileChanged(fsys, app, fsnotifyRemoveEvent("content/blog/index.tpl")))
+	require.NotContains(t, ve.templates, "content/blog/index.tpl",
+		"Remove must drop the cached template")
+}
+
+// .tpl Create on a path that has no cached entry must load fresh.
+func TestFileChangedTplCreateLoads(t *testing.T) {
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"content/blog/index.tpl": {
+			Data: []byte(`<!--layout:site-->
+{{define "content"}}<p>fresh</p>{{end}}`),
+		},
+	}
+	app := &App{
+		mux:          http.NewServeMux(),
+		routes:       map[string]*Routing{},
+		viewers:      map[string]Viewer{},
+		contentViews: map[string]*ContentView{},
+		funcMap:      template.FuncMap{},
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	ve := &HtmlViewEngine{fsys: fsys, contentDirs: []string{"content"}, app: app}
+	ve.templates = map[string]*HtmlTemplate{}
+	ve.md = newContentRenderer()
+	// Skip Load — simulate a runtime that has no template yet.
+	require.NotContains(t, ve.templates, "content/blog/index.tpl")
+
+	require.NoError(t, ve.FileChanged(fsys, app, fsnotifyEvent("content/blog/index.tpl", fsnotify.Create)))
+	require.Contains(t, ve.templates, "content/blog/index.tpl",
+		"Create on missing entry must load the template")
+}
+
 // =============================================================================
 // helpers
 // =============================================================================
@@ -660,6 +951,10 @@ func fsnotifyRemoveEvent(name string) fsnotify.Event {
 
 func fsnotifyWriteEvent(name string) fsnotify.Event {
 	return fsnotify.Event{Name: name, Op: fsnotify.Write}
+}
+
+func fsnotifyEvent(name string, op fsnotify.Op) fsnotify.Event {
+	return fsnotify.Event{Name: name, Op: op}
 }
 
 // Avoid an "imported and not used" warning if any helper above becomes unused.

--- a/docs/content.md
+++ b/docs/content.md
@@ -23,9 +23,9 @@ The content engine does not introduce a new `Viewer`, a new routing registration
 
 The content engine does **not** parse YAML/TOML frontmatter. Title is derived from the first `# H1` heading. Description is derived from the first blockquote (preferred) or top-level paragraph. Everything else comes from the filesystem.
 
-### Principle 0.3 — No content-specific layout file
+### Principle 0.3 — Templates and pages use distinct extensions
 
-There is no `content/_layout.html`, no `content/_index.html`, no `content/_tags.html`. Every HTML template in the content directory is a standard `HtmlViewEngine` page that uses `<!--layout:NAME-->` to reference the same `layouts/` directory used by every other page on the site.
+Inside `content/`, `.tpl` files are **bubble-up templates only** — they are loaded into the template graph but never registered as routes. `.html` files are **pages only** — they register a route and are not consulted during bubble-up lookup. This separation is what lets a directory such as `content/blog/` carry both a wrapping template (`index.tpl`) and a real Markdown page (`index.md`) without the template occupying the route.
 
 ### Principle 0.4 — Markdown files are read at runtime
 
@@ -54,24 +54,28 @@ pages/                       ← Non-content pages (unchanged)
 
 content/                     ← Content directory (default; configurable via WithContentDir)
 ├── hello.md                 ← Auto-registered: GET /hello
-├── hello.html               ← Optional specific template for /hello
+├── hello.tpl                ← Bubble-up template for /hello (optional, sibling .md)
+├── hello.html               ← Standalone page for /hello (optional, sibling .md)
 ├── 2026/
-│   ├── index.html           ← Bubble-up target for sibling .md files
+│   ├── index.tpl            ← Bubble-up template for sibling .md files (no route)
+│   ├── index.md             ← Directory-level page: GET /2026/  (own H1, breadcrumb anchor)
 │   ├── deeper.md            ← Auto-registered: GET /2026/deeper
-│   └── deeper.html          ← Optional specific template
+│   └── deeper.tpl           ← Optional specific template for /2026/deeper
 └── about.md                 ← Auto-registered: GET /about
 ```
 
 Three rules govern this layout:
 
-**Rule 1.1 — Bubble-up template lookup**
+**Rule 1.1 — Bubble-up template lookup (`.tpl` only)**
 
-For any route `R` derived from a `.md` file, the engine looks for an HTML template in this order:
+For any route `R` derived from a `.md` file, the engine looks for a bubble-up template in this order:
 
-1. `R` itself with `.html` extension (e.g. `content/2026/deeper.html`)
-2. The directory of `R` (e.g. `content/2026/index.html`)
-3. Each ancestor directory's `index.html` (e.g. `content/index.html`)
-4. The root `index.html`
+1. `R` itself with `.tpl` extension (e.g. `content/2026/deeper.tpl`)
+2. The directory of `R` (e.g. `content/2026/index.tpl`)
+3. Each ancestor directory's `index.tpl` (e.g. `content/index.tpl`)
+4. The root `index.tpl`
+
+`.html` files in `content/` are not consulted during bubble-up. The directory-level page at `/2026/` exists **independently** of the bubble-up template at `content/2026/index.tpl`.
 
 **Rule 1.2 — Auto route registration for `.md`**
 
@@ -301,31 +305,36 @@ func (ve *HtmlViewEngine) loadContentFile(mdPath string) error {
 ### 4.5 `bubbleUp` — template lookup
 
 ```go
-// bubbleUp finds the best HTML template for a slug.
+// bubbleUp finds the best bubble-up template for a slug.
 //
 // For slug "2026/deeper", in order:
-//   1. content/2026/deeper.html
-//   2. content/2026/index.html
-//   3. content/index.html
-//   4. index.html
+//   1. content/2026/deeper.tpl
+//   2. content/2026/index.tpl
+//   3. content/index.tpl
+//   4. index.tpl
+//
+// .html files in the content tree are NOT candidates — they are page
+// routes, not templates. Templates live exclusively under .tpl so a
+// directory such as content/blog/ can hold both index.tpl (template)
+// and index.md (real page at /blog/) without conflict.
 func (ve *HtmlViewEngine) bubbleUp(slug string) string {
     full := path.Join(ve.contentDir, slug)
 
-    if existsFS(ve.fsys, full+".html") {
-        return full + ".html"
+    if existsFS(ve.fsys, full+".tpl") {
+        return full+".tpl"
     }
 
     dir := path.Dir(full)
     for dir != "." && dir != "/" && dir != "" {
-        candidate := path.Join(dir, "index.html")
+        candidate := path.Join(dir, "index.tpl")
         if existsFS(ve.fsys, candidate) {
             return candidate
         }
         dir = path.Dir(dir)
     }
 
-    if existsFS(ve.fsys, "index.html") {
-        return "index.html"
+    if existsFS(ve.fsys, "index.tpl") {
+        return "index.tpl"
     }
     return ""
 }
@@ -483,9 +492,9 @@ GET /2026/deeper
 
 ## Section 9 — Template Authoring
 
-### 9.1 Content page template
+### 9.1 Bubble-up template
 
-`content/hello.html`:
+`content/hello.tpl` (sibling to `content/hello.md`):
 
 ```html
 <!--layout:site-->
@@ -507,6 +516,8 @@ GET /2026/deeper
 </article>
 {{end}}
 ```
+
+The `.tpl` extension tells the engine: load this as a template that wraps sibling `.md` content, **do not** register it as a route. `content/hello.html` would behave differently — it would be a standalone page at `GET /hello` and would never be picked up by `bubbleUp`.
 
 Note the `<div class="content-body">` wrapper. See Section 9.5 for why and how to style it.
 
@@ -772,10 +783,12 @@ This is an escape hatch — most users never need it.
 
 | Scenario | Behavior |
 |----------|----------|
-| `content/foo.md` with no `.html` fallback anywhere | Warning log. Route is not registered. Visiting `/foo` returns 404. |
-| `content/foo.md` + `content/foo.html` | Route `/foo` uses `foo.html` as template. |
-| `content/foo.md` + `content/index.html` | Route `/foo` uses `index.html` via bubble-up. |
-| `content/foo.md` + root `index.html` | Route `/foo` uses root `index.html` via bubble-up. |
+| `content/foo.md` with no `.tpl` fallback anywhere | Warning log. Route is not registered. Visiting `/foo` returns 404. |
+| `content/foo.md` + `content/foo.tpl` | Route `/foo` uses `foo.tpl` as template. |
+| `content/foo.md` + `content/index.tpl` | Route `/foo` uses `index.tpl` via bubble-up. |
+| `content/foo.md` + root `index.tpl` | Route `/foo` uses root `index.tpl` via bubble-up. |
+| `content/blog/index.tpl` + `content/blog/index.md` | Bubble-up template and a real directory-level page coexist. `GET /blog` renders `index.md` wrapped by `index.tpl`. |
+| `content/blog/index.tpl` only (no `index.md`) | No route at `/blog`; only sibling `.md` files under `blog/` are reachable. |
 | Markdown has no `# H1` | `ContentView.Title == ""`. Template must guard. |
 | Markdown has no blockquote or paragraph | `ContentView.Description == ""`. Template must guard. |
 | Markdown render fails (parser error) | Error log. `app.contentViews` not written. Route not registered. |

--- a/viewengine_html.go
+++ b/viewengine_html.go
@@ -109,6 +109,33 @@ func (ve *HtmlViewEngine) FileChanged(fsys fs.FS, app *App, event fsnotify.Event
 			return ve.loadContentFile(event.Name, dir)
 		}
 		return nil
+
+	case ".tpl":
+		dir, ok := ve.matchedContentDir(event.Name)
+		if !ok {
+			return nil
+		}
+		tmplKey := ve.templateKey(event.Name)
+		if event.Has(fsnotify.Remove) {
+			// No route to de-register (templates never register routes).
+			// Drop the cached template so a later loadContentFile with
+			// the same path rebuilds it from disk.
+			delete(ve.templates, tmplKey)
+			return nil
+		}
+		// Write/Create: prefer Reload so the existing HtmlTemplate
+		// instance stays in place — HtmlViewer entries in app.routes
+		// hold a pointer to that instance, and replacing it would leave
+		// them rendering the stale template. Reload also cascades to
+		// dependents via the dependency graph.
+		if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
+			if t, ok := ve.templates[tmplKey]; ok {
+				return t.Reload(fsys, ve.templates, app.funcMap)
+			}
+			_, err := ve.loadContentTemplate(event.Name, dir)
+			return err
+		}
+		return nil
 	}
 
 	return nil
@@ -215,12 +242,17 @@ func (ve *HtmlViewEngine) loadView(path string) error {
 
 // loadContent walks every configured content directory and dispatches by
 // file extension:
-//   - .md   → loadContentFile (parse, render, register route via bubble-up)
-//   - .html → loadContentPage (register as a regular page route)
+//   - .md   → loadContentFile       (parse, render, register route via bubble-up)
+//   - .html → loadContentPage       (register as a regular page route)
+//   - .tpl  → loadContentTemplate   (load as a bubble-up template; no route)
 //
 // Subdirectories are walked recursively. Each content directory becomes
 // a URL prefix; e.g. blog/post.md → /blog/post and docs/api/intro.md →
 // /docs/api/intro.
+//
+// The split between .html and .tpl is what makes directory-level pages
+// possible: a directory may carry an index.tpl (template) and an
+// index.md (real page at /<dir>/) without the template occupying the route.
 func (ve *HtmlViewEngine) loadContent() {
 	for _, dir := range ve.contentDirs {
 		if dir == "" {
@@ -240,6 +272,10 @@ func (ve *HtmlViewEngine) loadContent() {
 			case ".html":
 				if err := ve.loadContentPage(p, dir); err != nil {
 					ve.app.logger.Error("xun: load content page", slog.String("path", p), slog.Any("err", err))
+				}
+			case ".tpl":
+				if _, err := ve.loadContentTemplate(p, dir); err != nil {
+					ve.app.logger.Error("xun: load content template", slog.String("path", p), slog.Any("err", err))
 				}
 			}
 			return nil
@@ -299,17 +335,19 @@ func (ve *HtmlViewEngine) loadContentFile(mdPath, dir string) error {
 
 	tmplPath := ve.bubbleUp(mdPath)
 	if tmplPath == "" {
-		ve.app.logger.Warn("xun: content has no html template",
+		ve.app.logger.Warn("xun: content has no bubble-up template",
 			slog.String("path", mdPath), slog.String("slug", cv.Slug))
 		return nil
 	}
 
-	// Load the bubble-up template if it hasn't been loaded yet.
+	// Load the bubble-up template if it hasn't been loaded yet. The key
+	// preserves the extension so a sibling .tpl and .html at the same
+	// path don't overwrite each other.
 	tmplKey := ve.templateKey(tmplPath)
 	t, ok := ve.templates[tmplKey]
 	if !ok {
 		var err error
-		t, err = ve.loadTemplateOnly(tmplPath, dir)
+		t, err = ve.loadContentTemplate(tmplPath, dir)
 		if err != nil {
 			return err
 		}
@@ -324,16 +362,22 @@ func (ve *HtmlViewEngine) loadContentFile(mdPath, dir string) error {
 	return nil
 }
 
-// loadTemplateOnly parses an HTML file into ve.templates without registering
-// any route. Use this for shared bubble-up targets that multiple .md files
-// route through.
-func (ve *HtmlViewEngine) loadTemplateOnly(htmlPath, dir string) (*HtmlTemplate, error) {
-	name := strings.TrimPrefix(htmlPath, dir+"/")
-	t := NewHtmlTemplate(name, htmlPath)
+// loadContentTemplate parses a template file (.tpl or .html) inside a
+// content directory into ve.templates WITHOUT registering any route.
+// It is used for:
+//   - .tpl files: pure bubble-up targets that wrap sibling .md files.
+//   - .html files: loaded here so loadContentPage can attach a route to
+//     the same template; the route registration is performed separately.
+//
+// The template key is derived from the file path with its extension
+// stripped so multiple .md files can share one bubble-up .tpl template.
+func (ve *HtmlViewEngine) loadContentTemplate(tplPath, dir string) (*HtmlTemplate, error) {
+	name := strings.TrimPrefix(tplPath, dir+"/")
+	t := NewHtmlTemplate(name, tplPath)
 	if err := t.Load(ve.fsys, ve.templates, ve.app.funcMap); err != nil {
 		return nil, err
 	}
-	ve.templates[ve.templateKey(htmlPath)] = t
+	ve.templates[ve.templateKey(tplPath)] = t
 	return t, nil
 }
 
@@ -341,6 +385,9 @@ func (ve *HtmlViewEngine) loadTemplateOnly(htmlPath, dir string) (*HtmlTemplate,
 // as a page route in its own right, the same way loadPage does for pages/.
 // This is used for .html files in content directories that are pages on
 // their own (not bubble-up targets for .md files).
+//
+// In the current convention .html files in content/ are pages only — they
+// are NEVER consulted by bubbleUp. That role belongs to .tpl files.
 func (ve *HtmlViewEngine) loadContentPage(htmlPath, dir string) error {
 	if htmlPath != dir && !strings.HasPrefix(htmlPath, dir+"/") {
 		return nil
@@ -351,7 +398,7 @@ func (ve *HtmlViewEngine) loadContentPage(htmlPath, dir string) error {
 		rel = ""
 	}
 
-	t, err := ve.loadTemplateOnly(htmlPath, dir)
+	t, err := ve.loadContentTemplate(htmlPath, dir)
 	if err != nil {
 		return err
 	}
@@ -368,20 +415,25 @@ func (ve *HtmlViewEngine) loadContentPage(htmlPath, dir string) error {
 	return nil
 }
 
-// bubbleUp finds the best matching HTML template path for a .md file.
+// bubbleUp finds the best matching bubble-up template for a .md file.
+//
+// Only .tpl files are candidates. .html files in content/ are page routes,
+// not templates, so they are intentionally skipped from the lookup
+// (so a directory such as content/blog/ can hold both an index.tpl template
+// and an index.md page without the template occupying the route).
 //
 // Order (scoped to its own content directory):
-//  1. <mdPath-without-.md>.html
-//  2. <dir>/<sub>/index.html  (walking up the directory chain)
-//  3. <dir>/index.html
-//  4. root index.html
+//  1. <mdPath-without-.md>.tpl
+//  2. <dir>/<sub>/index.tpl  (walking up the directory chain)
+//  3. <dir>/index.tpl
+//  4. root index.tpl
 //
 // Returns "" when no template is found.
 func (ve *HtmlViewEngine) bubbleUp(mdPath string) string {
 	full := strings.TrimSuffix(mdPath, ".md")
 
-	if existsFS(ve.fsys, full+".html") {
-		return full + ".html"
+	if existsFS(ve.fsys, full+".tpl") {
+		return full + ".tpl"
 	}
 
 	dir, _ := ve.matchedContentDir(mdPath)
@@ -391,25 +443,35 @@ func (ve *HtmlViewEngine) bubbleUp(mdPath string) string {
 
 	cur := path.Dir(full)
 	for cur != "." && cur != "/" && cur != "" && cur != dir {
-		candidate := path.Join(cur, "index.html")
+		candidate := path.Join(cur, "index.tpl")
 		if existsFS(ve.fsys, candidate) {
 			return candidate
 		}
 		cur = path.Dir(cur)
 	}
 
-	if existsFS(ve.fsys, path.Join(dir, "index.html")) {
-		return path.Join(dir, "index.html")
+	if existsFS(ve.fsys, path.Join(dir, "index.tpl")) {
+		return path.Join(dir, "index.tpl")
 	}
-	if existsFS(ve.fsys, "index.html") {
-		return "index.html"
+	if existsFS(ve.fsys, "index.tpl") {
+		return "index.tpl"
 	}
 	return ""
 }
 
-// templateKey returns the lookup key used to store *HtmlTemplate in ve.templates.
+// templateKey returns the lookup key used to store *HtmlTemplate in
+// ve.templates for files inside a content directory.
+//
+// Unlike loadTemplate (which strips .html from components/, layouts/,
+// pages/, views/ keys), templateKey preserves the file extension so that
+// a content/blog/index.tpl and a content/blog/index.html can coexist
+// without overwriting each other. They are two separate templates with
+// distinct roles — one is a bubble-up target, the other is a page.
+//
+// The legacy loadTemplate path keeps its stripped-name convention
+// because components/layouts/pages/views never carry .tpl siblings.
 func (ve *HtmlViewEngine) templateKey(p string) string {
-	return p[:len(p)-len(".html")]
+	return p
 }
 
 // renderMarkdown dispatches to the user-provided renderFn when available,

--- a/viewer_breadcrumb_test.go
+++ b/viewer_breadcrumb_test.go
@@ -143,7 +143,7 @@ func TestBuildBreadcrumbEmptyTitleIsKept(t *testing.T) {
 
 func TestBreadcrumbEndToEndMarkdown(t *testing.T) {
 	fsys := fstest.MapFS{
-		"index.html": {Data: []byte(`<nav>{{range .Breadcrumb}}{{if .Last}}[{{.Name}}|{{.Title}}]{{else}}<a href="{{.Path}}">{{.Name}}</a>{{end}}{{end}}</nav>`)},
+		"index.tpl": {Data: []byte(`<nav>{{range .Breadcrumb}}{{if .Last}}[{{.Name}}|{{.Title}}]{{else}}<a href="{{.Path}}">{{.Name}}</a>{{end}}{{end}}</nav>`)},
 		"blog/2026/x.md": {Data: []byte("# 深入 Xun\n\n正文.")},
 	}
 


### PR DESCRIPTION
## Why

A `content/` directory could not hold both a wrapping template and a directory-level page: with the old convention the bubble-up lookup and the page route registration both targeted `index.html`, so `content/blog/index.html` (template) and `content/blog/index.md` (page at `/blog/`) could not coexist. The same path served both jobs, and whichever won starved the other. This split makes the roles disjoint — one extension per job — so a directory like `content/blog/` can legitimately carry an `index.tpl` template that wraps sibling posts AND an `index.md` that renders as `GET /blog/`.

## What changed

- Bubble-up templates inside `content/` are now `.tpl` files (loaded into the template graph, never registered as routes).
- `.html` files inside `content/` are now page routes only (registered as routes, never consulted by bubble-up).
- `fsnotify` watch now handles `.tpl` write/create/remove; writes reload the cached `*HtmlTemplate` in place so existing `HtmlViewer` entries keep seeing the live template.
- `templateKey` for content files preserves the file extension so a sibling `index.tpl` and `index.html` at the same path no longer overwrite each other in `ve.templates`.

## Diff overview

- `viewengine_html.go` (`bubbleUp`, `loadContent`, `loadContentTemplate`, `loadContentPage`, `templateKey`, `FileChanged`): the convention change is concentrated here. `bubbleUp` now probes `.tpl` exclusively and walks ancestors looking for `index.tpl`. The new `loadContentTemplate` replaces `loadTemplateOnly` and now serves both `.tpl` (pure template) and `.html` (template that `loadContentPage` will attach a route to). `templateKey` no longer strips `.html` from content paths — two files with different extensions now keep distinct cache slots. `FileChanged` gained a `.tpl` branch: Remove drops the cache, Write/Create prefer `Reload` over allocating a new `*HtmlTemplate` so route viewers do not silently shadow the old template.
- `README.md`: rewritten the "Content engine" section to describe the `.tpl` vs `.html` split, updated the directory layout example (`hello.tpl`, `2026/index.tpl`, `2026/index.md`), and rewrote the bubble-up rule to enumerate `.tpl` candidates only. Added an explicit note that `.tpl` files never register routes and `.html` files never act as bubble-up targets.
- `docs/content.md`: principle 0.3 rewritten ("Templates and pages use distinct extensions"), rule 1.1 retitled (".tpl only") with a clarifying sentence about `.html` exclusion, the directory tree diagram extended with `index.tpl` / `index.md` siblings, the worked example sections reference `content/hello.tpl`, and the lookup-rules table now includes the coexisting-template-and-page case plus the template-only case (no route at the directory, sibling `.md` files still reachable).
- `content_test.go`: existing end-to-end / bubble-up / multiple-content-dirs / file-changed tests renamed their template fixtures from `index.html` to `index.tpl` (the old fixtures would now be treated as page routes). Added `TestContentTemplateNotRegistered` (bare `index.tpl` yields 404), `TestContentTemplateAndPageCoexist` (`index.tpl` + `index.md` produce two distinct routes that share the wrapper), `TestContentHtmlNotBubbleUp` (a sibling `.html` does not leak into bubble-up), `TestFileChangedTplWriteReloadsInPlace` (Write preserves `*HtmlTemplate` identity so the cached route viewer keeps rendering the new content), `TestFileChangedTplRemoveClearsCache`, and `TestFileChangedTplCreateLoads`. Added a small `fsnotifyEvent` helper for event construction.
- `viewer_breadcrumb_test.go`: the breadcrumb fixture's `index.html` was renamed to `index.tpl` to match the new content convention.

## Test evidence

- Existing content engine tests (`TestContentEngineEndToEnd`, `TestContentEngineBubbleUpToRoot`, `TestBubbleUpNotFound`, `TestWithContentMultiple`, `TestWithContentAccumulates`, `TestWithContentEmptyDisables`, `TestWithContentRenderer`, `TestWithContentMeta`, `TestFileChangedContentRemove`, `TestFileChangedContentOutsideDirIgnored`) updated and re-verified under the `.tpl` convention.
- New tests cover the four behaviour boundaries: `.tpl` alone does not register, `.tpl` + `.md` coexist, `.html` is excluded from bubble-up, and fsnotify on `.tpl` preserves `*HtmlTemplate` identity across write/remove/create.
- Tests: ran locally via `go test ./...` — full content-engine suite passes. Manual verification of `viewer_breadcrumb_test.go` confirms the breadcrumb chain still resolves when the directory anchor is a `.tpl` wrapping a `.md` page.

## Summary by Sourcery

Separate content templates from page routes by adopting `.tpl` for bubble-up templates and `.html` for standalone routes.

New Features:
- Support distinct `.tpl` bubble-up templates and `.html` content page routes, allowing directory-level Markdown pages and wrapping templates to coexist.

Bug Fixes:
- Prevent content templates with different extensions from colliding in the template cache.
- Keep cached template instances updated in place when `.tpl` files change so existing viewers render live content.

Enhancements:
- Update content template discovery and file watching to enforce the new extension-specific conventions.

Documentation:
- Document the `.tpl` versus `.html` content conventions, lookup behavior, and supported directory layouts.

Tests:
- Add coverage for template-only content, template/page coexistence, `.html` exclusion from bubble-up, cache separation, and `.tpl` file lifecycle updates.