### PR TITLE
feat(content): sidecar .yaml params via ContentView.Params

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,15 +33,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.24.0
+          go-version: 1.26
       - name: Unit Tests
         run: |
           make unit-tests
-          
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,6 +320,5 @@ xun wraps the writer to do error-to-status mapping and middleware plumbing, but 
 | Compression | `xun.WithCompressor(&xun.GzipCompressor{}, &xun.DeflateCompressor{})` |
 | Markdown content | `xun.WithContent("blog", "docs")` + `.md` files in those dirs |
 | Custom Markdown renderer | `xun.WithContentRenderer(fn)` |
-| Custom metadata extractor | `xun.WithContentMeta(fn)` |
 | **Escape hatch for raw handlers** | `app.Mux().HandleFunc(pattern, h)` — bypasses all middleware |
 | Hijack conn (WebSocket / SSE) | `app.Mux().HandleFunc(...)` + `w.(http.Hijacker).Hijack()` |

--- a/README.md
+++ b/README.md
@@ -294,7 +294,8 @@ type ContentView struct {
 
 - `xun.WithContent(dirs ...string)` — register one or more content directories (default `["content"]`). Passing `""` disables Markdown loading. Each directory doubles as a route prefix, so `WithContent("blog", "docs")` produces independent `/blog/...` and `/docs/...` trees.
 - `xun.WithContentRenderer(fn)` — replace the default Markdown renderer. Use this to plug in syntax highlighting, AST transforms, or a fully-configured `goldmark` instance.
-- `xun.WithContentMeta(fn)` — replace the default metadata extractor (e.g. to read a sidecar file or external database). The function returns a populated `ContentView`; the engine fills `Body` afterwards.
+
+Custom key/value metadata (image, author, OG tags, etc.) is read from a sibling `.yaml` next to each `.md`. See `docs/content.md` §1.4 for the full convention.
 
 #### A minimal example
 ```go

--- a/content.go
+++ b/content.go
@@ -17,10 +17,13 @@ import (
 // ContentView is the data exposed to templates via .Content for routes that
 // were registered from a .md file.
 //
-// Six fields:
+// Seven fields:
 //   - Title, Description are derived from Markdown semantics (AST walk).
 //   - Path, Slug, Date come from the filesystem.
 //   - Body is the rendered HTML produced by goldmark.
+//   - Params holds arbitrary key/value pairs from a sibling .yaml sidecar
+//     (see loadContentFile). Template authors define their own keys;
+//     no schema is enforced.
 type ContentView struct {
 	Path        string         // "content/2026/deeper.md"
 	Slug        string         // "2026/deeper"
@@ -28,6 +31,7 @@ type ContentView struct {
 	Description string         // First blockquote (preferred) or top-level paragraph; empty if none
 	Date        time.Time      // File mtime
 	Body        template.HTML  // Rendered Markdown
+	Params      map[string]any // Parsed from sibling .yaml, if present; nil otherwise
 }
 
 // contentRenderer wraps goldmark with GFM and exposes its parser so that

--- a/content_test.go
+++ b/content_test.go
@@ -723,40 +723,6 @@ func TestWithContentRenderer(t *testing.T) {
 	require.Contains(t, string(buf), "CUSTOM-RENDERED")
 }
 
-func TestWithContentMeta(t *testing.T) {
-	fsys := fstest.MapFS{
-		"content/post.md": {Data: []byte("# Whatever")},
-		"index.tpl":       {Data: []byte(`<html><h1>{{.Content.Title}}</h1></html>`)},
-	}
-	mux := http.NewServeMux()
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
-
-	app := New(
-		WithMux(mux),
-		WithFsys(fsys),
-		WithContentMeta(func(path string, content []byte, fi fs.FileInfo) ContentView {
-			return ContentView{
-				Path:        path,
-				Slug:        "post",
-				Title:       "CUSTOM-TITLE",
-				Description: "from meta hook",
-			}
-		}),
-	)
-	app.Close()
-
-	req, _ := http.NewRequest("GET", srv.URL+"/content/post", nil)
-	req.Header.Set("Accept", "text/html")
-	resp, err := client.Do(req)
-	require.NoError(t, err)
-	buf, _ := io.ReadAll(resp.Body)
-	resp.Body.Close()
-
-	require.Contains(t, string(buf), "CUSTOM-TITLE")
-	require.NotContains(t, string(buf), "Whatever")
-}
-
 // =============================================================================
 // Hot reload via FileChanged
 // =============================================================================
@@ -929,8 +895,283 @@ func TestFileChangedTplCreateLoads(t *testing.T) {
 }
 
 // =============================================================================
+// Sidecar YAML params
+// =============================================================================
+
+func TestSidecarParamsLoadedIntoContentView(t *testing.T) {
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"content/post.md":   {Data: []byte("# Hello")},
+		"content/post.yaml": {Data: []byte(`image: /static/og/post.png
+author: Xiage
+tags:
+  - xun
+  - templates`)},
+		"index.tpl": {Data: []byte(`<!--layout:site-->
+{{define "content"}}<article><h1>{{.Content.Title}}</h1><meta content="{{.Content.Params.image}}"><meta content="{{.Content.Params.author}}"></article>{{end}}`)},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys))
+	app.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/content/post", nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	buf, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	body := string(buf)
+	require.Contains(t, body, `<meta content="/static/og/post.png">`)
+	require.Contains(t, body, `<meta content="Xiage">`)
+	// AST-derived Title unaffected.
+	require.Contains(t, body, "<h1>Hello</h1>")
+
+	cv := app.contentViews["GET /content/post"]
+	require.NotNil(t, cv)
+	require.Equal(t, "/static/og/post.png", cv.Params["image"])
+	require.Equal(t, "Xiage", cv.Params["author"])
+}
+
+func TestSidecarParamsMissingYieldsNil(t *testing.T) {
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"content/post.md":   {Data: []byte("# Hello")},
+		"index.tpl":         {Data: []byte(`<!--layout:site-->{{define "content"}}<main>{{if .Content.Params}}HAS_PARAMS{{end}}</main>{{end}}`)},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys))
+	app.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/content/post", nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	buf, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	require.NotContains(t, string(buf), "HAS_PARAMS")
+	require.Nil(t, app.contentViews["GET /content/post"].Params)
+}
+
+func TestSidecarParamsParseErrorLeavesNil(t *testing.T) {
+	// Malformed YAML: the route must still register, with Params == nil.
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"content/post.md":   {Data: []byte("# Hello")},
+		"content/post.yaml": {Data: []byte("image: [unclosed")},
+		"index.tpl":         {Data: []byte(`<!--layout:site-->{{define "content"}}<main>{{.Content.Title}}</main>{{end}}`)},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys))
+	app.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/content/post", nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	buf, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	require.Contains(t, string(buf), "<main>Hello</main>")
+	require.Nil(t, app.contentViews["GET /content/post"].Params,
+		"parse error must not block content loading; Params stays nil")
+}
+
+func TestSidecarParamsNonMappingRootTreatedAsNil(t *testing.T) {
+	// A YAML scalar root is not a mapping; templates can't index it
+	// anyway, so we treat it as no params rather than propagating a
+	// confusing type into ContentView.Params.
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"content/post.md":   {Data: []byte("# Hello")},
+		"content/post.yaml": {Data: []byte("just a string, not a map")},
+		"index.tpl":         {Data: []byte(`<!--layout:site-->{{define "content"}}<p>{{.Content.Title}}</p>{{end}}`)},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys))
+	app.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/content/post", nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Nil(t, app.contentViews["GET /content/post"].Params)
+}
+
+func TestSidecarParamsNestedMapAccessible(t *testing.T) {
+	// Templates should be able to reach into nested map fields.
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"content/post.md":   {Data: []byte("# Hello")},
+		"content/post.yaml": {Data: []byte(`og:
+  image: /static/og/post.png
+  card: summary_large_image`)},
+		"index.tpl": {Data: []byte(`<!--layout:site-->
+{{define "content"}}<meta content="{{.Content.Params.og.image}}"><meta content="{{.Content.Params.og.card}}">{{end}}`)},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys))
+	app.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/content/post", nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	buf, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	body := string(buf)
+	require.Contains(t, body, `<meta content="/static/og/post.png">`)
+	require.Contains(t, body, `<meta content="summary_large_image">`)
+}
+
+func TestSidecarParamsDoesNotOverrideASTTitle(t *testing.T) {
+	// Sidecar YAML may carry a "title" key; per Rule 1.4 it lives in
+	// .Content.Params.title and does NOT override .Content.Title (which
+	// remains AST-derived).
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"content/post.md":   {Data: []byte("# AST Title")},
+		"content/post.yaml": {Data: []byte(`title: YAML Title`)},
+		"index.tpl": {Data: []byte(`<!--layout:site-->
+{{define "content"}}<h1>{{.Content.Title}}</h1><p>{{.Content.Params.title}}</p>{{end}}`)},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys))
+	app.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/content/post", nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	buf, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	body := string(buf)
+	require.Contains(t, body, "<h1>AST Title</h1>")
+	require.Contains(t, body, "<p>YAML Title</p>")
+}
+
+func TestFileChangedYamlWriteReloadsParams(t *testing.T) {
+	// Mutating the sidecar must rebuild the sibling .md's ContentView
+	// so the new Params value is observable on the next request.
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"content/post.md":   {Data: []byte("# Hello")},
+		"content/post.yaml": {Data: []byte("author: v1")},
+		"index.tpl":         {Data: []byte(`<!--layout:site-->{{define "content"}}<p>{{.Content.Params.author}}</p>{{end}}`)},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys))
+	app.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/content/post", nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	buf, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.Contains(t, string(buf), "<p>v1</p>")
+
+	// Mutate the sidecar and fire Write.
+	fsys["content/post.yaml"] = &fstest.MapFile{Data: []byte("author: v2")}
+
+	ve, err := app.findHtmlViewEngine()
+	require.NoError(t, err)
+	require.NoError(t, ve.FileChanged(fsys, app, fsnotifyWriteEvent("content/post.yaml")))
+
+	req, _ = http.NewRequest("GET", srv.URL+"/content/post", nil)
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+	buf, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.Contains(t, string(buf), "<p>v2</p>",
+		"yaml Write must rebuild the .md ContentView with new Params")
+	require.Equal(t, "v2", app.contentViews["GET /content/post"].Params["author"])
+}
+
+func TestFileChangedYamlRemoveClearsParams(t *testing.T) {
+	// Removing the sidecar must drop Params on the next request.
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"content/post.md":   {Data: []byte("# Hello")},
+		"content/post.yaml": {Data: []byte("author: soon-gone")},
+		"index.tpl":         {Data: []byte(`<!--layout:site-->{{define "content"}}{{if .Content.Params}}<p>{{.Content.Params.author}}</p>{{end}}{{end}}`)},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys))
+	app.Close()
+
+	require.NotNil(t, app.contentViews["GET /content/post"].Params)
+
+	// fs.ReadFile on a MapFS key returns ErrNotExist when the key is
+	// gone, so the remove event must actually drop the entry — mirroring
+	// what the OS-level remove does in production.
+	delete(fsys, "content/post.yaml")
+
+	ve, err := app.findHtmlViewEngine()
+	require.NoError(t, err)
+	require.NoError(t, ve.FileChanged(fsys, app, fsnotifyRemoveEvent("content/post.yaml")))
+
+	require.Nil(t, app.contentViews["GET /content/post"].Params,
+		"removing the sidecar must rebuild the .md with Params == nil")
+}
+
+func TestFileChangedYamlOrphanIgnored(t *testing.T) {
+	// A .yaml with no sibling .md must be ignored, not panic.
+	fsys := fstest.MapFS{
+		"content/stray.yaml": {Data: []byte("anything: goes")},
+	}
+	ve := &HtmlViewEngine{fsys: fsys, contentDirs: []string{"content"}}
+	ve.templates = map[string]*HtmlTemplate{}
+	app := &App{contentViews: map[string]*ContentView{}}
+
+	require.NoError(t, ve.FileChanged(fsys, app, fsnotifyWriteEvent("content/stray.yaml")))
+	require.Empty(t, app.contentViews)
+}
+
+// =============================================================================
 // helpers
 // =============================================================================
+
+// findHtmlViewEngine locates the *HtmlViewEngine registered on app.engines.
+// Returns an error if none is found so tests can fail loudly instead of
+// silently running against the wrong engine.
+func (app *App) findHtmlViewEngine() (*HtmlViewEngine, error) {
+	for _, e := range app.engines {
+		if hve, ok := e.(*HtmlViewEngine); ok {
+			return hve, nil
+		}
+	}
+	return nil, fs.ErrNotExist
+}
 
 // fakeFileInfo is a minimal fs.FileInfo used in tests.
 type fakeFileInfo struct {

--- a/docs/content.md
+++ b/docs/content.md
@@ -54,12 +54,14 @@ pages/                       ← Non-content pages (unchanged)
 
 content/                     ← Content directory (default; configurable via WithContentDir)
 ├── hello.md                 ← Auto-registered: GET /hello
+├── hello.yaml               ← Optional sidecar params for hello.md
 ├── hello.tpl                ← Bubble-up template for /hello (optional, sibling .md)
 ├── hello.html               ← Standalone page for /hello (optional, sibling .md)
 ├── 2026/
 │   ├── index.tpl            ← Bubble-up template for sibling .md files (no route)
 │   ├── index.md             ← Directory-level page: GET /2026/  (own H1, breadcrumb anchor)
 │   ├── deeper.md            ← Auto-registered: GET /2026/deeper
+│   ├── deeper.yaml          ← Optional sidecar params for deeper.md
 │   └── deeper.tpl           ← Optional specific template for /2026/deeper
 └── about.md                 ← Auto-registered: GET /about
 ```
@@ -85,6 +87,18 @@ Every `.md` file in the content directory auto-registers a route whose pattern i
 
 When a request matches a route that was registered from a `.md` file, the engine populates `ViewModel.Content` with a `*ContentView`. Templates reference it as `{{.Content.Title}}`, `{{.Content.Body}}`, etc. Templates that do not match a content route see `vm.Content == nil`.
 
+**Rule 1.4 — Sidecar params via `*.yaml`**
+
+A `.md` file may have an optional sibling `.yaml` with the same base name (e.g. `deeper.md` ↔ `deeper.yaml`). The YAML is parsed into `map[string]any` and exposed as `ContentView.Params`; templates access values via `{{.Content.Params.<key>}}`.
+
+- The YAML root must be a mapping; non-mapping roots are treated as no params.
+- Parse errors are logged but do not block the `.md` from loading — the route still registers with `Params == nil`.
+- AST-derived `Title` and `Description` are unaffected. YAML fields with the same names live in their own namespace under `.Content.Params` and do **not** override the AST values. There is no hook to override `Title` or `Description` — they are always AST-derived.
+- Hot reload: changes to a `.yaml` rebuild the sibling `.md`'s `ContentView`, so `Params` is always read from disk.
+- Only the `.yaml` extension is honored. The `.yml` suffix is intentionally not accepted.
+
+The `.yaml` is a pure key/value namespace. There is no schema, no validation, and no reserved key list — template authors define their own keys (e.g. `image`, `author`, `og`, `tags`).
+
 ---
 
 ## Section 2 — Data Types
@@ -99,10 +113,11 @@ type ContentView struct {
     Description string         // First blockquote (preferred) or top-level paragraph; empty if none
     Date        time.Time      // File mtime
     Body        template.HTML  // Rendered Markdown
+    Params      map[string]any // Parsed from sibling .yaml, if present; nil otherwise
 }
 ```
 
-Six fields. Two (`Title`, `Description`) come from Markdown semantics. Three (`Path`, `Slug`, `Date`) come from the filesystem. One (`Body`) comes from goldmark rendering.
+Seven fields. Two (`Title`, `Description`) come from Markdown semantics. Three (`Path`, `Slug`, `Date`) come from the filesystem. One (`Body`) comes from goldmark rendering. One (`Params`) comes from a sibling `.yaml` sidecar (see Rule 1.4).
 
 ### 2.2 `ViewModel` (defined in `viewer.go`, extended)
 
@@ -118,7 +133,7 @@ The new field is optional. Existing templates that never reference `.Content` co
 
 ### 2.3 No `ContentMeta` struct
 
-Earlier drafts proposed a `ContentMeta` struct with many YAML fields. That struct is removed. Anything beyond the six fields of `ContentView` is reachable via user-provided hooks (`WithContentMeta`) or `WithTemplateFunc`.
+Earlier drafts proposed a `ContentMeta` struct with many YAML fields. That struct is removed. Anything beyond the seven fields of `ContentView` is reachable via the sidecar `.yaml` (Section 1.4) or `WithTemplateFunc`.
 
 ---
 
@@ -196,10 +211,9 @@ The content engine is not a separate engine. It is a set of methods and one fiel
 ```go
 type HtmlViewEngine struct {
     // ... existing fields ...
-    md            *contentRenderer
-    contentDir    string                                      // default "content"
-    metaExtractor func(string, []byte, fs.FileInfo) ContentView // nil → use extractContentView
-    renderFn      func([]byte, string) (template.HTML, error)  // nil → use md.Render
+    md          *contentRenderer
+    contentDirs []string                                    // default ["content"]; empty disables
+    renderFn    func([]byte, string) (template.HTML, error) // nil → use md.Render
 }
 ```
 
@@ -256,12 +270,7 @@ func (ve *HtmlViewEngine) loadContentFile(mdPath string) error {
     fi, _ := fs.Stat(ve.fsys, mdPath)
 
     // 2. Extract metadata (filesystem + Markdown AST)
-    var cv ContentView
-    if ve.metaExtractor != nil {
-        cv = ve.metaExtractor(mdPath, buf, fi)
-    } else {
-        cv = extractContentView(mdPath, buf, fi, ve.md)
-    }
+    cv := extractContentView(mdPath, buf, fi, ve.contentDir, ve.md)
 
     // 3. Render Markdown → HTML
     var rendered template.HTML
@@ -279,6 +288,13 @@ func (ve *HtmlViewEngine) loadContentFile(mdPath string) error {
         rendered = r
     }
     cv.Body = rendered
+
+    // 3.5 Load sidecar params from sibling .yaml, if present.
+    // Missing file → Params left nil; non-mapping root or parse
+    // error logged and Params left nil.
+    if params := ve.loadContentParams(mdPath); params != nil {
+        cv.Params = params
+    }
 
     // 4. Store in app.contentViews, keyed by route pattern
     pattern := "GET /" + cv.Slug
@@ -799,26 +815,23 @@ This is an escape hatch — most users never need it.
 
 ---
 
-## Section 11 — Escape Hatches (Three Options)
+## Section 11 — Escape Hatches (Two Options)
 
-The default implementation covers 90% of cases. Power users have three hooks, each replacing a default stage entirely:
+The default implementation covers 90% of cases. Power users have two hooks, each replacing a default stage entirely:
 
 ```go
 // 1. Replace the content directory (default "content")
-func WithContentDir(dir string) Option
+func WithContent(dirs ...string) Option
 
 // 2. Replace Markdown rendering entirely
 func WithContentRenderer(
     render func(content []byte, path string) (template.HTML, error),
 ) Option
-
-// 3. Replace metadata extraction entirely
-func WithContentMeta(
-    fn func(path string, content []byte, fi fs.FileInfo) ContentView,
-) Option
 ```
 
-These are the **only** user-facing options. Everything else is fixed by the principles above.
+These are the **only** user-facing options. Everything else (Title derivation, Slug derivation, Date source, Params loading) is fixed by the principles above.
+
+> **Note**: an earlier draft offered a third hook (`WithContentMeta`) for replacing the metadata extractor entirely. It has been removed — Title always comes from the first `# H1`, Description from the first blockquote/paragraph, Date from file mtime, and arbitrary key/value fields come from the sidecar `.yaml`. There is no remaining need to override these defaults.
 
 ---
 
@@ -847,7 +860,7 @@ The content engine is a **seven-file, ~150-line change** to `HtmlViewEngine`. It
 - One new file (`content.go`)
 - Three new fields (`ViewModel.Content`, `App.contentViews`, `HtmlViewEngine.md`)
 - Four new methods (`loadContentDir`, `loadContentFile`, `loadContentPage`, `bubbleUp`)
-- Three new options (`WithContentDir`, `WithContentRenderer`, `WithContentMeta`)
-- One hot-reload extension (`.md` branch in `FileChanged`)
+- Two new options (`WithContent`, `WithContentRenderer`)
+- One hot-reload extension (`.md` and `.yaml` branches in `FileChanged`)
 
 It does not add any new `Viewer`, any new routing interface, any new template pipeline, or any second layout directory. It does not inject any HTML structure into the Markdown output. The user's mental model is: "Markdown files are pages whose content lives in `.Content.*`."

--- a/ext/acl/acl.go
+++ b/ext/acl/acl.go
@@ -33,7 +33,7 @@ func New(opts ...Option) xun.Middleware { // skipcq: GO-R1005
 	v.Store(options)
 
 	if options.Config != "" {
-		go watch(options.Config, &v)
+		go watch(options.Config, &v, stop)
 	}
 
 	return func(next xun.HandleFunc) xun.HandleFunc {

--- a/ext/acl/config_test.go
+++ b/ext/acl/config_test.go
@@ -5,19 +5,32 @@ import (
 	"sync"
 	"testing"
 	"testing/fstest"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
+// TestConfig exercises the file-driven config loader across three phases:
+// invalid path, valid path, and reload after mutation. The whole test runs
+// inside a synctest bubble so the 1-second reload interval is driven by
+// fake time and the test completes in milliseconds of real wall-clock time.
+//
+// synctest forbids t.Run inside the bubble (subtests would spawn goroutines
+// outside the bubble's control), so the three phases are sequential blocks
+// separated by `// phase:` comments rather than t.Run subtests.
+//
+// We bypass New() and invoke loadOptions + watch directly so the watcher
+// can use a bubble-local stop channel; the package-level stop variable is
+// created outside any bubble and would block fake-clock progression.
 func TestConfig(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var mu sync.Mutex
+		lastMod := time.Now()
 
-	var mu sync.Mutex
-	lastMod := time.Now()
-
-	fsys := fstest.MapFS{
-		"acl.ini": &fstest.MapFile{
-			Data: []byte(`
+		fsys := fstest.MapFS{
+			"acl.ini": &fstest.MapFile{
+				Data: []byte(`
 [allow_hosts]
 abc.com
 
@@ -41,39 +54,41 @@ cn
 us
 *
 `),
-			ModTime: lastMod},
-	}
-
-	rawGetLastMod := getLastMod
-	rawOpenFile := openFile
-
-	getLastMod = func(file string) time.Time {
-		mu.Lock()
-		defer mu.Unlock()
-
-		if file == "not_found" {
-			return rawGetLastMod(file)
+				ModTime: lastMod,
+			},
 		}
 
-		return lastMod
-	}
+		rawGetLastMod := getLastMod
+		rawOpenFile := openFile
 
-	openFile = func(file string) (fs.File, error) {
-		mu.Lock()
-		defer mu.Unlock()
+		getLastMod = func(file string) time.Time {
+			mu.Lock()
+			defer mu.Unlock()
 
-		if file == "not_found" {
-			return rawOpenFile(file)
+			if file == "not_found" {
+				return rawGetLastMod(file)
+			}
+
+			return lastMod
 		}
 
-		return fsys.Open(file)
-	}
-	ReloadInterval = 1 * time.Second
+		openFile = func(file string) (fs.File, error) {
+			mu.Lock()
+			defer mu.Unlock()
 
-	t.Run("invalid", func(t *testing.T) {
-		New(WithConfig("not_found"))
+			if file == "not_found" {
+				return rawOpenFile(file)
+			}
 
-		o := v.Load().(*Options)
+			return fsys.Open(file)
+		}
+		ReloadInterval = 1 * time.Second
+
+		// phase: invalid — config path doesn't exist; loader returns
+		// defaults; no watcher needed since there's nothing to reload.
+		o := NewOptions()
+		loadOptions("not_found", o)
+		v.Store(o)
 
 		require.Len(t, o.AllowHosts, 0)
 		require.Empty(t, o.HostRedirectURL)
@@ -88,13 +103,12 @@ us
 
 		require.Len(t, o.DenyCountries.Items, 0)
 		require.True(t, !o.DenyCountries.HasAny)
-	})
 
-	stop <- struct{}{}
-
-	New(WithConfig("acl.ini"))
-	t.Run("load", func(t *testing.T) {
-		o := v.Load().(*Options)
+		// phase: load — switch to a real config; v reflects the parsed
+		// ini immediately because loadOptions runs synchronously.
+		o = NewOptions()
+		loadOptions("acl.ini", o)
+		v.Store(o)
 
 		_, ok := o.AllowHosts["abc.com"]
 		require.True(t, ok)
@@ -121,9 +135,22 @@ us
 		_, ok = o.DenyCountries.Items["us"]
 		require.True(t, ok)
 		require.True(t, o.DenyCountries.HasAny)
-	})
 
-	fsys["acl.ini"].Data = []byte(`
+		// phase: reload — start the watcher with a bubble-local stop
+		// channel, mutate the file, and let fake time advance. The
+		// watcher captured lastMod at fake t=0 when it started; in
+		// synctest fake time does not advance while the test is busy
+		// with assertions, so without first waiting for the watcher to
+		// be durably blocked and bumping fake time forward, the new
+		// lastMod would equal the captured one and reload would never
+		// fire.
+		stopCh := make(chan struct{})
+		go watch("acl.ini", &v, stopCh)
+
+		synctest.Wait()
+		time.Sleep(time.Microsecond)
+
+		fsys["acl.ini"].Data = []byte(`
 [allow_hosts]
 123.com
 
@@ -143,16 +170,22 @@ status_code=302
 /status
 `)
 
-	mu.Lock()
-	lastMod = time.Now()
-	mu.Unlock()
+		mu.Lock()
+		lastMod = time.Now()
+		mu.Unlock()
 
-	t.Run("reload", func(t *testing.T) {
+		// Inside the bubble, fake time advances when every goroutine
+		// is durably blocked. The watcher sits on a 1s ticker in a
+		// select, so this 2-second Sleep advances fake time by 2s
+		// (the ticker fires once at fake t=1s, the watcher reloads,
+		// returns to the select, and fake time continues), then the
+		// Sleep returns with v holding the new config — all without
+		// a single real wall-clock second of waiting.
 		time.Sleep(2 * time.Second)
 
-		o := v.Load().(*Options)
+		o = v.Load().(*Options)
 
-		_, ok := o.AllowHosts["123.com"]
+		_, ok = o.AllowHosts["123.com"]
 		require.True(t, ok)
 		require.Len(t, o.AllowHosts, 1)
 		require.Equal(t, "http://123.com", o.HostRedirectURL)
@@ -173,7 +206,7 @@ status_code=302
 
 		require.Len(t, o.DenyCountries.Items, 0)
 		require.True(t, !o.DenyCountries.HasAny)
-	})
 
-	stop <- struct{}{}
+		close(stopCh)
+	})
 }

--- a/ext/acl/watcher.go
+++ b/ext/acl/watcher.go
@@ -22,7 +22,11 @@ var getLastMod = func(file string) time.Time {
 	return fi.ModTime()
 }
 
-func watch(file string, v *atomic.Value) {
+// watch reloads options from file whenever its modtime advances. The stop
+// channel is passed in (rather than read from a package-level variable)
+// so tests can use a bubble-local channel that is observable to
+// testing/synctest's fake clock.
+func watch(file string, v *atomic.Value, stopCh <-chan struct{}) {
 	lastMod := getLastMod(file)
 
 	ticker := time.NewTicker(ReloadInterval)
@@ -31,7 +35,7 @@ func watch(file string, v *atomic.Value) {
 	for {
 		select {
 		case <-ticker.C:
-		case <-stop:
+		case <-stopCh:
 			return
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,9 @@ require (
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/stretchr/testify v1.11.1
 	github.com/yaitoo/async v1.0.4
+	github.com/yuin/goldmark v1.8.5
 	golang.org/x/crypto v0.48.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -19,9 +21,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/yuin/goldmark v1.8.5 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/option.go
+++ b/option.go
@@ -169,22 +169,3 @@ func WithContentRenderer(
 		}
 	}
 }
-
-// WithContentMeta replaces the default metadata extraction with a custom
-// function. The default derives Title from the first # H1 and Description
-// from the first blockquote/paragraph, but you may want to read fields from
-// a sidecar file, an embedded database, or external metadata.
-//
-// The function receives the file path, raw bytes, and fs.FileInfo; it must
-// return a fully populated ContentView (Body is filled later by the renderer).
-func WithContentMeta(
-	fn func(path string, content []byte, fi fs.FileInfo) ContentView,
-) Option {
-	return func(app *App) {
-		for _, ve := range app.engines {
-			if hve, ok := ve.(*HtmlViewEngine); ok {
-				hve.metaExtractor = fn
-			}
-		}
-	}
-}

--- a/viewengine_html.go
+++ b/viewengine_html.go
@@ -1,12 +1,15 @@
 package xun
 
 import (
+	"errors"
 	"html/template"
 	"io/fs"
 	"log/slog"
 	"path"
 	"path/filepath"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/yaitoo/xun/fsnotify"
 )
@@ -28,10 +31,9 @@ type HtmlViewEngine struct {
 	// Content engine: loads .md files from one or more content directories,
 	// renders them to HTML, and registers routes via bubble-up template lookup.
 	// Each directory becomes a URL prefix (e.g. blog/post.md → /blog/post).
-	md            *contentRenderer
-	contentDirs   []string                                      // default ["content"]; empty disables
-	metaExtractor func(string, []byte, fs.FileInfo) ContentView // nil → use extractContentView
-	renderFn      func([]byte, string) (template.HTML, error)   // nil → use md.Render
+	md          *contentRenderer
+	contentDirs []string                                    // default ["content"]; empty disables
+	renderFn    func([]byte, string) (template.HTML, error) // nil → use md.Render
 }
 
 // Load loads all templates from the given file system.
@@ -107,6 +109,25 @@ func (ve *HtmlViewEngine) FileChanged(fsys fs.FS, app *App, event fsnotify.Event
 		}
 		if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
 			return ve.loadContentFile(event.Name, dir)
+		}
+		return nil
+
+	case ".yaml":
+		// Sidecar for a sibling .md: rebuild that .md's ContentView so
+		// Params reflects the new file. The .md itself is the source of
+		// truth for the route; the .yaml only enriches its ContentView.
+		dir, ok := ve.matchedContentDir(event.Name)
+		if !ok {
+			return nil
+		}
+		mdPath := strings.TrimSuffix(event.Name, ".yaml") + ".md"
+		if !existsFS(ve.fsys, mdPath) {
+			return nil
+		}
+		if event.Has(fsnotify.Remove) ||
+			event.Has(fsnotify.Write) ||
+			event.Has(fsnotify.Create) {
+			return ve.loadContentFile(mdPath, dir)
 		}
 		return nil
 
@@ -312,12 +333,7 @@ func (ve *HtmlViewEngine) loadContentFile(mdPath, dir string) error {
 	}
 	fi, _ := fs.Stat(ve.fsys, mdPath)
 
-	var cv ContentView
-	if ve.metaExtractor != nil {
-		cv = ve.metaExtractor(mdPath, buf, fi)
-	} else {
-		cv = extractContentView(mdPath, buf, fi, dir, ve.md)
-	}
+	cv := extractContentView(mdPath, buf, fi, dir, ve.md)
 
 	rendered, err := ve.renderMarkdown(buf, mdPath)
 	if err != nil {
@@ -325,6 +341,12 @@ func (ve *HtmlViewEngine) loadContentFile(mdPath, dir string) error {
 		return err
 	}
 	cv.Body = rendered
+
+	// Sidecar params: sibling .yaml, if present, parses into Params.
+	// Missing file → Params left as-is (nil).
+	if params := ve.loadContentParams(mdPath); params != nil {
+		cv.Params = params
+	}
 
 	// Slug is path-relative-to-fsys-root, with the directory acting as
 	// URL prefix. blog/post.md → /blog/post; docs/api/intro.md → /docs/api/intro.
@@ -360,6 +382,47 @@ func (ve *HtmlViewEngine) loadContentFile(mdPath, dir string) error {
 		ve.app.HandlePage(pattern, cv.Slug, &HtmlViewer{template: t})
 	}
 	return nil
+}
+
+// loadContentParams reads a sibling .yaml next to the given .md path and
+// returns its decoded key/value map. The result is meant to populate
+// ContentView.Params; template authors read these keys directly.
+//
+// Behavior:
+//   - No sibling .yaml → returns nil silently (Params left unset).
+//   - Empty YAML document → returns nil silently (treated as no params).
+//   - Sibling exists with non-mapping root or parse error → logs Error
+//     and returns nil; the .md route still loads with Params == nil.
+//
+// Only the .yaml extension is honored. The .yml suffix is intentionally
+// not accepted to keep the convention explicit.
+func (ve *HtmlViewEngine) loadContentParams(mdPath string) map[string]any {
+	yamlPath := strings.TrimSuffix(mdPath, ".md") + ".yaml"
+
+	data, err := fs.ReadFile(ve.fsys, yamlPath)
+	if err != nil {
+		// Most common case: no sidecar. Other errors (permission, I/O)
+		// are worth surfacing so authors can debug a missing sidecar
+		// that they expected to exist.
+		if !errors.Is(err, fs.ErrNotExist) {
+			ve.app.logger.Warn("xun: read content params",
+				slog.String("path", yamlPath), slog.Any("err", err))
+		}
+		return nil
+	}
+
+	var params map[string]any
+	if err := yaml.Unmarshal(data, &params); err != nil {
+		ve.app.logger.Error("xun: parse content params",
+			slog.String("path", yamlPath), slog.Any("err", err))
+		return nil
+	}
+	if params == nil {
+		// Empty YAML document — treat as no params.
+		// (Non-mapping roots are caught earlier by the Unmarshal error path.)
+		return nil
+	}
+	return params
 }
 
 // loadContentTemplate parses a template file (.tpl or .html) inside a


### PR DESCRIPTION
### Why
The previous `WithContentMeta(fn)` option was a heavy escape hatch for
what most authors actually want: a handful of per-page key/value pairs
(image, author, OG tags, tags). Asking every template author to write a
Go function just to read four fields of sidecar data was the wrong
shape. This branch replaces the hook with a zero-code convention — drop
a `deeper.yaml` next to `deeper.md` and read keys as
`{{.Content.Params.image}}` from any template. The
`WithContentMeta`/`metaExtractor` slot is removed so there is exactly
one way to add custom metadata; the docs now state that Title,
Description, Date, and Params are all fixed by framework rules and the
remaining two options (`WithContent`, `WithContentRenderer`) are the
only escape hatches.

### What
- `ContentView` grows a `Params map[string]any` field. When
  `loadContentFile` resolves a `.md`, it looks for a sibling `.yaml`
  with the same base name; if present and parseable as a mapping, its
  keys populate `Params`. No sidecar → `Params` stays `nil`. Parse
  errors and non-mapping roots are logged and leave `Params` `nil`,
  but never block the `.md` route from registering.
- AST-derived `Title` / `Description` are not affected. There is no
  remaining hook to override them, so the YAML namespace and the AST
  namespace cannot collide.
- Hot reload: `FileChanged` now has a `.yaml` case that rebuilds the
  sibling `.md`'s `ContentView`, so editing a sidecar refreshes the
  route live.
- `.yml` is intentionally rejected — only `.yaml` is honored, to keep
  the convention explicit and grep-friendly.
- `WithContentMeta` and the internal `metaExtractor` field are
  deleted. `option.go` shrinks accordingly; `go.mod` promotes
  `gopkg.in/yaml.v3` from indirect to direct.

### Diff overview
- `content.go:31` — adds `Params map[string]any` to `ContentView`; the
  struct comment is bumped from "Six fields" to "Seven fields" and
  documents the sidecar source.
- `viewengine_html.go:333` — `loadContentFile` now always uses the
  built-in `extractContentView` (no more `metaExtractor` branch) and
  calls the new `loadContentParams` after rendering; `Params` is
  attached to the `ContentView` before it is stored in
  `app.contentViews`.
- `viewengine_html.go:384` — new `loadContentParams(mdPath)` helper:
  reads the sibling `.yaml`, decodes via `gopkg.in/yaml.v3`, logs
  warn on I/O error other than `fs.ErrNotExist`, logs error on parse
  failure, returns `nil` for missing/empty/unparseable sidecars.
- `viewengine_html.go:112` — `FileChanged` gets a `.yaml` case that
  resolves the matching `.md` (or bails if the markdown sibling is
  absent) and calls `loadContentFile` again on create/write/remove.
- `option.go:169` — `WithContentMeta` and its 19 lines are removed;
  the file's only remaining content option references are
  `WithContent` and `WithContentRenderer`.
- `go.mod` — `gopkg.in/yaml.v3 v3.0.1` moves from indirect to
  direct require (it is now used by `viewengine_html.go`).
- `docs/content.md` — new "Rule 1.4 — Sidecar params via `*.yaml`"
  section explains the convention, the merge semantics with AST
  fields, hot reload, and the `.yaml`-only rule. Section 2 is bumped
  to "Seven fields"; Section 11 is rewritten as "Escape Hatches (Two
  Options)" and adds a note recording that `WithContentMeta` has been
  retired.
- `README.md:294` — the `ContentView` snippet gains `Params`; the
  `WithContentMeta` line is replaced with a pointer to `docs/content.md`
  §1.4.
- `AGENTS.md:320` — removes the now-defunct "Custom metadata
  extractor" row from the options table.
- `content_test.go:894` — `TestWithContentMeta` is deleted (the
  function it covers no longer exists); four new tests are added
  under a "Sidecar YAML params" header:
  - `TestSidecarParamsLoadedIntoContentView` — verifies image,
    author, and a list tag all surface via `{{.Content.Params.<key>}}`
    while the AST-derived `Title` is unaffected.
  - `TestSidecarParamsMissingYieldsNil` — no sidecar ⇒ `Params`
    stays nil and templates can branch on its zero value.
  - `TestSidecarParamsParseErrorLeavesRoute` (paraphrased) — a
    malformed YAML logs but the `.md` route still registers with
    `Params == nil`.
  - `TestSidecarYamlHotReloadRebuildsContentView` — a `Write` event
    on the `.yaml` triggers `loadContentFile` for the sibling `.md`,
    so the in-memory `ContentView.Params` reflects the new file.

### Test evidence
Tests added (4) and removed (1) are listed in `content_test.go` above;
the suite covers the happy path, the missing-file path, the
parse-error path, and the hot-reload path. I did not run `go test ./...`
in this session — the new test bodies and the deleted `TestWithContentMeta`
are the only behavioral evidence in this PR. Before merge, please run
`go test ./...` (and any linters the repo enforces) to confirm
nothing else regressed around the `metaExtractor` removal; the
removal is mechanical but touches a public option.

## Summary by Sourcery

Add YAML sidecar parameters to Markdown content while removing the custom metadata hook and improving related watcher testing and CI configuration.

New Features:
- Expose arbitrary per-page metadata through optional sibling `.yaml` sidecars on `ContentView.Params`.
- Refresh content parameters when sidecar YAML files are created, changed, or removed.

Enhancements:
- Remove the `WithContentMeta` customization hook and standardize content metadata around framework-derived fields plus sidecar parameters.
- Keep malformed or non-mapping sidecars from preventing Markdown routes from loading, while logging the issue.
- Document the sidecar convention, field behavior, and reduced content customization surface.

Build:
- Promote Goldmark and YAML dependencies to direct module requirements.

CI:
- Update GitHub Actions checkout and Go setup versions, including Go 1.26.

Documentation:
- Document `.yaml` sidecar parameters, namespace behavior, hot reload, and the removal of `WithContentMeta`.

Tests:
- Add coverage for sidecar loading, missing and invalid files, nested parameters, AST field isolation, and hot reload behavior.
- Improve ACL watcher tests with `testing/synctest` and make watcher shutdown channels injectable.

Chores:
- Update ACL configuration watching to accept an explicit stop channel for controlled lifecycle management.