### PR TITLE
fix(content): register index.html/index.md at canonical /<dir>/{$} (#120)

### DIFF
--- a/content_test.go
+++ b/content_test.go
@@ -419,8 +419,9 @@ func TestContentTemplateAndPageCoexist(t *testing.T) {
 	app := New(WithMux(mux), WithFsys(fsys))
 	app.Close()
 
-	// Directory-level page: GET /content/blog/index renders index.md wrapped by index.tpl.
-	req, _ := http.NewRequest("GET", srv.URL+"/content/blog/index", nil)
+	// Directory-level page: GET /content/blog renders index.md wrapped by index.tpl.
+	// Per docs/content.md §1, index.md resolves to /<dir>/ (not /<dir>/index).
+	req, _ := http.NewRequest("GET", srv.URL+"/content/blog", nil)
 	req.Header.Set("Accept", "text/html")
 	resp, err := client.Do(req)
 	require.NoError(t, err)
@@ -443,10 +444,11 @@ func TestContentTemplateAndPageCoexist(t *testing.T) {
 	require.Contains(t, body, "第一篇")
 
 	// Both routes should have their own ContentView so the breadcrumb
-	// chain can carry H1s for the ancestor directory.
-	require.Contains(t, app.contentViews, "GET /content/blog/index")
+	// chain can carry H1s for the ancestor directory. The directory-level
+	// page lives at the directory root (canonical /<dir>/{$}).
+	require.Contains(t, app.contentViews, "GET /content/blog/{$}")
 	require.Contains(t, app.contentViews, "GET /content/blog/post")
-	require.Equal(t, "博客首页", app.contentViews["GET /content/blog/index"].Title)
+	require.Equal(t, "博客首页", app.contentViews["GET /content/blog/{$}"].Title)
 }
 
 // .html in content/ is a page route only — it must NOT be picked up by
@@ -550,6 +552,254 @@ func TestContentTplAndHtmlCoexistInSameDir(t *testing.T) {
 	require.Contains(t, body, "Body text")
 	require.NotContains(t, body, "standalone html page",
 		"post must NOT be rendered through the index.html page template")
+}
+
+// =============================================================================
+// loadContentPage route registration (issue #120)
+// =============================================================================
+
+// Regression for issue #120: with xun.WithContent("blog") and an
+// app/blog/index.html present, the page must register at GET /blog/{$}
+// (the canonical directory root), not at GET /index as a TrimSuffix-of-rel
+// bug produced. The broken logic stripped the dir prefix before slicing
+// /index.html off, so rel became "index.html" and the suffix strip was
+// a no-op.
+//
+// The convention for loadContentPage mirrors loadPage: index.html maps
+// to /<dir>/{$} so both the trailing-slash canonical URL (/blog/) is
+// served directly and the no-slash form (/blog) gets a single 307
+// redirect to it. Registering both /blog AND /blog/{$} would create two
+// duplicate pages in SEO crawlers — ServeMux's built-in redirect is the
+// canonical pattern.
+func TestContentPageIndexHtmlRegistersAtDirRoot(t *testing.T) {
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"blog/index.html": {Data: []byte(`<!--layout:site-->
+{{define "content"}}<p>directory landing page</p>{{end}}`)},
+		"blog/welcome.html": {Data: []byte(`<!--layout:site-->
+{{define "content"}}<p>welcome page</p>{{end}}`)},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys), WithContent("blog"))
+	app.Close()
+
+	// /blog/ — the canonical URL — must serve directly.
+	req, _ := http.NewRequest("GET", srv.URL+"/blog/", nil)
+	req.Header.Set("Accept", "text/html")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	buf, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Contains(t, string(buf), "directory landing page")
+
+	// /blog (no slash) must 307-redirect to /blog/, NOT serve duplicate
+	// content. This is the SEO contract — only /blog/ is canonical.
+	noRedirect := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	req2, _ := http.NewRequest("GET", srv.URL+"/blog", nil)
+	resp2, err := noRedirect.Do(req2)
+	require.NoError(t, err)
+	resp2.Body.Close()
+	require.Equal(t, http.StatusTemporaryRedirect, resp2.StatusCode,
+		"/blog must redirect (307) to the canonical /blog/ — no duplicate route")
+	require.Equal(t, "/blog/", resp2.Header.Get("Location"))
+
+	// Sibling welcome.html — dir prefix stripped by the loadContentPage
+	// convention, so the route is GET /welcome (not GET /blog/welcome).
+	req, _ = http.NewRequest("GET", srv.URL+"/welcome", nil)
+	req.Header.Set("Accept", "text/html")
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+	buf, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Contains(t, string(buf), "welcome page")
+
+	// Route table: only the canonical /blog/{$} is registered (no /blog
+	// route, no /index route). SplitFile expands the trailing slash into
+	// {$} so http.ServeMux handles the non-slash redirect for us.
+	require.NotContains(t, app.routes, "GET /index",
+		"the old broken GET /index pattern must not be registered")
+	require.NotContains(t, app.routes, "GET /blog",
+		"GET /blog would create a duplicate-content route; let ServeMux 307-redirect to /blog/")
+	require.Contains(t, app.routes, "GET /blog/{$}",
+		"index.html must register as the directory root with {$}")
+	require.Contains(t, app.routes, "GET /welcome")
+}
+
+// Same regression at the default content dir ("content"): the in-content
+// prefix is stripped before registering, so content/blog/index.html maps
+// to GET /blog/{$} (the canonical directory root inside the content
+// tree). /blog gets a 307 redirect to /blog/ — same SEO contract as the
+// WithContent("blog") case above.
+func TestContentPageIndexHtmlNestedDefaultDir(t *testing.T) {
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"content/blog/index.html": {Data: []byte(`<!--layout:site-->
+{{define "content"}}<p>blog landing</p>{{end}}`)},
+		"content/blog/welcome.html": {Data: []byte(`<!--layout:site-->
+{{define "content"}}<p>welcome</p>{{end}}`)},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys))
+	app.Close()
+
+	// /blog/ — canonical — serves directly.
+	req, _ := http.NewRequest("GET", srv.URL+"/blog/", nil)
+	req.Header.Set("Accept", "text/html")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	buf, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Contains(t, string(buf), "blog landing")
+
+	// /blog (no slash) must 307-redirect to /blog/.
+	noRedirect := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	req2, _ := http.NewRequest("GET", srv.URL+"/blog", nil)
+	resp2, err := noRedirect.Do(req2)
+	require.NoError(t, err)
+	resp2.Body.Close()
+	require.Equal(t, http.StatusTemporaryRedirect, resp2.StatusCode)
+	require.Equal(t, "/blog/", resp2.Header.Get("Location"))
+
+	// /content/blog/index — the old broken pattern must NOT exist
+	req3, _ := http.NewRequest("GET", srv.URL+"/content/blog/index", nil)
+	resp, err = client.Do(req3)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode,
+		"the broken pattern GET /content/blog/index must not be registered")
+
+	require.Contains(t, app.routes, "GET /blog/{$}",
+		"index.html must register as the directory root inside content/, with {$}")
+	require.NotContains(t, app.routes, "GET /blog",
+		"GET /blog would duplicate GET /blog/{$}; let ServeMux 307-redirect instead")
+	require.Contains(t, app.routes, "GET /blog/welcome")
+	require.NotContains(t, app.routes, "GET /content/blog/index")
+	require.NotContains(t, app.routes, "GET /index")
+}
+
+// Hot-reload must re-register content/index.html at the directory root,
+// not at /index.
+func TestContentPageIndexHtmlCreateHotReload(t *testing.T) {
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+	}
+	app := &App{
+		mux:          http.NewServeMux(),
+		routes:       map[string]*Routing{},
+		viewers:      map[string]Viewer{},
+		contentViews: map[string]*ContentView{},
+		funcMap:      template.FuncMap{},
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	ve := &HtmlViewEngine{fsys: fsys, contentDirs: []string{"content"}, app: app}
+	ve.templates = map[string]*HtmlTemplate{}
+	ve.md = newContentRenderer()
+	ve.Load(fsys, app)
+
+	// File appears after startup — Create event.
+	fsys["content/blog/index.html"] = &fstest.MapFile{
+		Data: []byte(`<!--layout:site-->
+{{define "content"}}<p>hot</p>{{end}}`),
+	}
+	require.NoError(t, ve.FileChanged(fsys, app, fsnotifyEvent("content/blog/index.html", fsnotify.Create)))
+
+	require.Contains(t, app.routes, "GET /blog/{$}",
+		"hot reload must register index.html at the directory root")
+	require.NotContains(t, app.routes, "GET /index",
+		"hot reload must NOT reintroduce the broken /index pattern")
+	require.NotContains(t, app.routes, "GET /content/blog/index",
+		"hot reload must NOT register at the in-content path with /index suffix")
+}
+
+// index.md (directory-level page) must register at /<dir>/{$} when a
+// bubble-up template exists, per docs/content.md §1 ("Directory-level
+// page: GET /<dir>/"). The trailing slash expands to {$} via splitFile,
+// matching only /<dir>/ and letting ServeMux 307-redirect /<dir> → /<dir>/
+// — same canonical-URL contract as pages/<dir>/index.html.
+func TestContentFileIndexMdRegistersAtDirRoot(t *testing.T) {
+	fsys := fstest.MapFS{
+		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"blog/index.tpl": {Data: []byte(`<!--layout:site-->
+{{define "content"}}<article>{{.Content.Title}} | {{.Content.Body}}</article>{{end}}`)},
+		"blog/index.md": {Data: []byte("# Blog Root\n\nIntro for the blog.")},
+		"blog/post.md": {Data: []byte("# Post\n\nPost body.")},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys), WithContent("blog"))
+	app.Close()
+
+	// /blog/ — canonical — serves index.md via the bubble-up template.
+	req, _ := http.NewRequest("GET", srv.URL+"/blog/", nil)
+	req.Header.Set("Accept", "text/html")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	buf, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := string(buf)
+	require.Contains(t, body, "<article>")
+	require.Contains(t, body, "Blog Root")
+	require.Contains(t, body, "Intro for the blog.")
+
+	// /blog (no slash) must 307-redirect to /blog/.
+	noRedirect := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	req2, _ := http.NewRequest("GET", srv.URL+"/blog", nil)
+	resp2, err := noRedirect.Do(req2)
+	require.NoError(t, err)
+	resp2.Body.Close()
+	require.Equal(t, http.StatusTemporaryRedirect, resp2.StatusCode)
+	require.Equal(t, "/blog/", resp2.Header.Get("Location"))
+
+	// /blog/index must NOT be a route — the trailing /index was stripped.
+	req3, _ := http.NewRequest("GET", srv.URL+"/blog/index", nil)
+	resp, err = client.Do(req3)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode,
+		"index.md must not be reachable at /<dir>/index")
+
+	// Sibling .md files use the same bubble-up template at their own paths.
+	req, _ = http.NewRequest("GET", srv.URL+"/blog/post", nil)
+	req.Header.Set("Accept", "text/html")
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+	buf, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	body = string(buf)
+	require.Contains(t, body, "<article>")
+	require.Contains(t, body, "Post")
+
+	require.Contains(t, app.routes, "GET /blog/{$}",
+		"directory-level page must register at the canonical /<dir>/{$}")
+	require.NotContains(t, app.routes, "GET /blog",
+		"GET /blog would duplicate /<dir>/{$}; let ServeMux 307-redirect instead")
+	require.Contains(t, app.routes, "GET /blog/post")
+	require.NotContains(t, app.routes, "GET /blog/index",
+		"the trailing /index must be stripped for index.md")
+	require.Contains(t, app.contentViews, "GET /blog/{$}",
+		"ContentView for the directory-level page lives at the canonical /<dir>/{$}")
+	require.NotContains(t, app.contentViews, "GET /blog/index")
 }
 
 // =============================================================================
@@ -737,11 +987,32 @@ func TestFileChangedContentRemove(t *testing.T) {
 
 	app := &App{
 		contentViews: map[string]*ContentView{
-			"GET /post": {Slug: "post", Title: "Hello"},
+			"GET /content/post": {Slug: "post", Title: "Hello"},
 		},
 	}
 
 	err := ve.FileChanged(fsys, app, fsnotifyRemoveEvent("content/post.md"))
+	require.NoError(t, err)
+	require.Empty(t, app.contentViews)
+}
+
+// Removing an index.md (directory-level page) must clear the route at
+// the canonical /<dir>/{$}, not at /<dir>/index.
+func TestFileChangedContentRemoveIndex(t *testing.T) {
+	fsys := fstest.MapFS{
+		"content/blog/index.tpl": {Data: []byte(`<p>x</p>`)},
+		"content/blog/index.md":  {Data: []byte("# Hello")},
+	}
+	ve := &HtmlViewEngine{fsys: fsys, contentDirs: []string{"content"}}
+	ve.templates = map[string]*HtmlTemplate{}
+
+	app := &App{
+		contentViews: map[string]*ContentView{
+			"GET /content/blog/{$}": {Slug: "blog", Title: "Hello"},
+		},
+	}
+
+	err := ve.FileChanged(fsys, app, fsnotifyRemoveEvent("content/blog/index.md"))
 	require.NoError(t, err)
 	require.Empty(t, app.contentViews)
 }

--- a/docs/content.md
+++ b/docs/content.md
@@ -83,6 +83,10 @@ For any route `R` derived from a `.md` file, the engine looks for a bubble-up te
 
 Every `.md` file in the content directory auto-registers a route whose pattern is `GET /<slug>`. The `<slug>` is the file path relative to the content directory, minus the `.md` extension.
 
+**Directory-level pages** (`index.md`) are a special case: the trailing `/index` segment of the slug is stripped and a `/` is appended so the route resolves to the canonical `/<dir>/{$}` pattern. `content/blog/index.md` therefore registers `GET /blog/{$}` (matching only `/blog/`), and `http.ServeMux` 307-redirects `/blog` → `/blog/`. This is the same canonical-URL contract `pages/<dir>/index.html` produces via `loadPage`, and avoids SEO duplicate content at `/<dir>` vs `/<dir>/`.
+
+`ContentView.Slug` keeps the literal `/index` segment (e.g. `Slug == "blog/index"` for `blog/index.md`) because the slug identifies the source file, not the route URL. The route URL is `GET /blog/{$}` — derivable from `Slug` only by stripping `/index` and appending `/`. Templates should treat `Slug` as the file-identity namespace; routing lookups use the contentView map key (see §3.4).
+
 **Rule 1.3 — Content lives in `ViewModel.Content`**
 
 When a request matches a route that was registered from a `.md` file, the engine populates `ViewModel.Content` with a `*ContentView`. Templates reference it as `{{.Content.Title}}`, `{{.Content.Body}}`, etc. Templates that do not match a content route see `vm.Content == nil`.
@@ -296,11 +300,21 @@ func (ve *HtmlViewEngine) loadContentFile(mdPath string) error {
         cv.Params = params
     }
 
-    // 4. Store in app.contentViews, keyed by route pattern
-    pattern := "GET /" + cv.Slug
+    // 4. Store in app.contentViews, keyed by route pattern.
+    //
+    // For directory-level pages (index.md), cv.Slug ends in "/index" —
+    // strip it and append "/" so splitFile expands the pattern to the
+    // canonical /<dir>/{$} form (matching only /<dir>/ with /<dir>
+    // getting a 307 redirect from http.ServeMux). For all other files
+    // the slug IS the route URL, so the pattern is "GET /" + cv.Slug.
+    patternBase := strings.TrimSuffix(cv.Slug + ".md", ".md")
+    if strings.HasSuffix(patternBase, "/index") {
+        patternBase = patternBase[:len(patternBase)-len("/index")] + "/"
+    }
+    _, _, pattern := splitFile(patternBase)
     ve.app.mu.Lock()
     ve.app.contentViews[pattern] = &cv
-    ve.app.mu.Unlock()
+    ve.app.Unlock()
 
     // 5. Bubble-up to find an HTML template
     tmplPath := ve.bubbleUp(cv.Slug)

--- a/viewengine_html.go
+++ b/viewengine_html.go
@@ -101,9 +101,9 @@ func (ve *HtmlViewEngine) FileChanged(fsys fs.FS, app *App, event fsnotify.Event
 			return nil
 		}
 		if event.Has(fsnotify.Remove) {
-			slug := strings.TrimSuffix(strings.TrimPrefix(event.Name, dir+"/"), ".md")
+			_, _, pattern := splitFile(contentPatternBase(event.Name))
 			app.mu.Lock()
-			delete(app.contentViews, "GET /"+slug)
+			delete(app.contentViews, pattern)
 			app.mu.Unlock()
 			return nil
 		}
@@ -350,7 +350,14 @@ func (ve *HtmlViewEngine) loadContentFile(mdPath, dir string) error {
 
 	// Slug is path-relative-to-fsys-root, with the directory acting as
 	// URL prefix. blog/post.md → /blog/post; docs/api/intro.md → /docs/api/intro.
-	pattern := "GET " + path.Join("/", strings.TrimSuffix(mdPath, ".md"))
+	//
+	// For directory-level pages (index.md), strip the trailing "/index"
+	// AND append a "/" so splitFile expands the route to /<dir>/{$} —
+	// matching only the canonical /<dir>/ (with trailing slash) and
+	// letting http.ServeMux 307-redirect /<dir> → /<dir>/. This is the
+	// same canonical-URL contract loadPage produces for pages/<dir>/index.html,
+	// and avoids SEO duplicate-content at /<dir> vs /<dir>/.
+	_, _, pattern := splitFile(contentPatternBase(mdPath))
 	ve.app.mu.Lock()
 	ve.app.contentViews[pattern] = &cv
 	ve.app.mu.Unlock()
@@ -451,29 +458,45 @@ func (ve *HtmlViewEngine) loadContentTemplate(tplPath, dir string) (*HtmlTemplat
 //
 // In the current convention .html files in content/ are pages only — they
 // are NEVER consulted by bubbleUp. That role belongs to .tpl files.
+//
+// Route resolution follows loadPage's slice-trim pattern. Stripping
+// "index.html" (10 chars) keeps the leading "/" so the URL stays
+// "blog/" rather than collapsing to "blog"; splitFile then expands
+// the trailing slash to "/<dir>/{$}" so both /<dir> and /<dir>/ match.
+// Stripping "/index.html" (11 chars) first would lose the slash —
+// and worse, slicing off the content-dir prefix before the trim would
+// leave a bare "index.html" with no leading slash, so the suffix match
+// silently no-ops and the route is registered at the broken GET /index.
 func (ve *HtmlViewEngine) loadContentPage(htmlPath, dir string) error {
 	if htmlPath != dir && !strings.HasPrefix(htmlPath, dir+"/") {
 		return nil
 	}
 
-	rel := strings.TrimPrefix(htmlPath, dir+"/")
-	if rel == htmlPath {
-		rel = ""
-	}
+	name := htmlPath
 
 	t, err := ve.loadContentTemplate(htmlPath, dir)
 	if err != nil {
 		return err
 	}
 
-	if strings.HasSuffix(htmlPath, "/index.html") {
-		rel = strings.TrimSuffix(rel, "/index.html")
+	if strings.HasSuffix(name, "/index.html") {
+		name = name[:len(name)-len("index.html")]
 	}
 
-	_, _, pattern := splitFile(rel)
+	// Strip the content-dir prefix to get the in-content path, but
+	// keep "dir/" intact when the file IS dir/index.html (the dir
+	// root IS the URL path in that case). For nested files inside
+	// dir/, stripping leaves the in-content path.
+	if strings.HasPrefix(name, dir+"/") {
+		if rest := name[len(dir)+1:]; rest != "" {
+			name = rest
+		}
+	}
+
+	_, _, pattern := splitFile(name)
 	pattern = strings.TrimSuffix(pattern, ".html")
 
-	ve.app.HandlePage(pattern, rel, &HtmlViewer{template: t})
+	ve.app.HandlePage(pattern, name, &HtmlViewer{template: t})
 
 	return nil
 }
@@ -550,4 +573,24 @@ func (ve *HtmlViewEngine) renderMarkdown(content []byte, path string) (template.
 func existsFS(fsys fs.FS, p string) bool {
 	_, err := fs.Stat(fsys, p)
 	return err == nil
+}
+
+// contentPatternBase returns the path string passed to splitFile to derive
+// the HTTP route pattern for a .md file inside a content directory. For
+// directory-level pages (index.md), the trailing "/index" is stripped and
+// "/" is appended so splitFile expands the route to /<dir>/{$} — matching
+// only the canonical /<dir>/ (with trailing slash) and letting
+// http.ServeMux 307-redirect /<dir> → /<dir>/.
+//
+// Both loadContentFile (on Create/Write) and FileChanged's .md Remove
+// branch must call this so the stored and deleted contentViews keys are
+// identical. Letting the two sites drift re-introduces the silent no-op
+// delete that the issue #120 fix closed: the route would never be removed
+// on file removal, leaking the ContentView until restart.
+func contentPatternBase(mdPath string) string {
+	base := strings.TrimSuffix(mdPath, ".md")
+	if strings.HasSuffix(base, "/index") {
+		base = base[:len(base)-len("/index")] + "/"
+	}
+	return base
 }

--- a/viewer_breadcrumb_test.go
+++ b/viewer_breadcrumb_test.go
@@ -99,6 +99,29 @@ func TestBuildBreadcrumbMarkdownAncestorCarriesOwnH1(t *testing.T) {
 	require.Equal(t, "深入 Xun", got[3].Title)
 }
 
+// After the loadContentFile / loadContentPage fix, directory-level pages
+// (index.md, index.html) register under the canonical /<dir>/{$} pattern.
+// The URL-derived breadcrumb prefix is the no-slash form (/blog), so the
+// lookup must fall back to /blog/{$}. This test pins that behavior.
+func TestBuildBreadcrumbMarkdownAncestorCanonicalPattern(t *testing.T) {
+	app := &App{
+		contentViews: map[string]*ContentView{
+			"GET /blog/{$}":     {Slug: "blog", Title: "博客首页"},
+			"GET /blog/post":    {Slug: "blog/post", Title: "第一篇"},
+		},
+	}
+	ctx := &Context{
+		App:     app,
+		Request: httptest.NewRequest(http.MethodGet, "/blog/post", nil),
+	}
+
+	got := buildBreadcrumb(ctx)
+	require.Len(t, got, 3)
+	require.Equal(t, "博客首页", got[1].Title,
+		"the /blog ancestor must resolve via the canonical /blog/{$} pattern even though the URL prefix is /blog")
+	require.Equal(t, "第一篇", got[2].Title)
+}
+
 func TestBuildBreadcrumbChineseSegmentIsRaw(t *testing.T) {
 	ctx := &Context{
 		Request: httptest.NewRequest(http.MethodGet, "/blog/深入探索", nil),
@@ -215,6 +238,43 @@ func TestBreadcrumbRootHasNoChain(t *testing.T) {
 	resp.Body.Close()
 
 	require.Equal(t, "NONE", string(buf))
+}
+
+// With the loadContentFile fix for directory-level pages, blog/index.md
+// registers at "GET /blog" (not /blog/index). A child post must therefore
+// pick up the directory-level H1 on the /blog ancestor of the breadcrumb chain,
+// not on a hypothetical /blog/index slot that no longer exists.
+func TestBreadcrumbEndToEndMarkdownIndexAncestor(t *testing.T) {
+	fsys := fstest.MapFS{
+		"layouts/index.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>
+<nav>{{range .Breadcrumb}}{{if .Last}}[{{.Name}}|{{.Title}}]{{else}}<a href="{{.Path}}"{{with .Title}} title="{{.}}"{{end}}>{{.Name}}</a>{{end}}{{end}}</nav>`)},
+		"blog/index.tpl": {Data: []byte(`<!--layout:index-->
+{{define "content"}}{{.Content.Body}}{{end}}`)},
+		"blog/index.md": {Data: []byte("# 博客首页\n\n这里是博客根页内容。")},
+		"blog/2026/x.md": {Data: []byte("# 深入 Xun\n\n正文.")},
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := New(WithMux(mux), WithFsys(fsys), WithContent("blog"))
+	app.Start()
+	defer app.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/blog/2026/x", nil)
+	req.Header.Set("Accept", "text/html")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	buf, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	body := string(buf)
+	require.Contains(t, body, `<a href="/">Home</a>`)
+	require.Contains(t, body, `<a href="/blog" title="博客首页">blog</a>`,
+		"/blog ancestor must carry the directory-level page's H1 from blog/index.md")
+	require.Contains(t, body, `<a href="/blog/2026">2026</a>`)
+	require.Contains(t, body, `[x|深入 Xun]`, "trailing item should render as plain with H1 title")
 }
 
 // =============================================================================
@@ -393,12 +453,15 @@ func TestBuildBreadcrumbDynamicMarkdownCurrentPage(t *testing.T) {
 
 func TestBuildBreadcrumbDynamicMarkdownAncestorUntouched(t *testing.T) {
 	// Ancestor items must still walk URL.Path; only the current page uses
-	// Routing.Pattern. The framework registers content/blog/index.md as
-	// "GET /blog/index" (the literal /index segment is preserved), so a
-	// request to /blog/index/foo walks the prefix /blog/index and finds it.
+	// Routing.Pattern. After the loadContentFile fix for directory-level
+	// pages, blog/index.md registers at "GET /blog" (not "GET /blog/index")
+	// per docs/content.md §1. So a request to /blog/index/foo walks the
+	// prefix /blog first and finds the directory-level page's title; the
+	// intermediate /blog/index segment has no entry because nothing is
+	// registered there.
 	app := &App{
 		contentViews: map[string]*ContentView{
-			"GET /blog/index":  {Title: "Blog Index"},
+			"GET /blog":        {Title: "Blog Index"},
 			"GET /blog/{slug}": {Title: "Post Title"},
 		},
 	}
@@ -410,7 +473,10 @@ func TestBuildBreadcrumbDynamicMarkdownAncestorUntouched(t *testing.T) {
 
 	got := buildBreadcrumb(ctx)
 	require.Len(t, got, 4)
-	require.Equal(t, "Blog Index", got[2].Title, "ancestor /blog/index resolves via URL-derived pattern")
+	require.Equal(t, "Blog Index", got[1].Title,
+		"ancestor /blog (the directory-level page) resolves via URL-derived pattern")
+	require.Empty(t, got[2].Title,
+		"intermediate /blog/index has no contentView (nothing is registered at that path)")
 	require.Equal(t, "Post Title", got[3].Title, "current page /blog/index/foo resolves via Routing.Pattern")
 }
 

--- a/viewer_html.go
+++ b/viewer_html.go
@@ -87,7 +87,14 @@ func buildBreadcrumb(ctx *Context) []BreadcrumbItem {
 
 		title := ""
 		if ctx.App != nil {
+			// Try the URL-derived pattern first; if that misses, fall back
+			// to the canonical /<dir>/{$} form so directory-level pages
+			// registered under loadContentFile/loadContentPage (which use
+			// /{$} per the SEO contract) still resolve when the URL prefix
+			// is the no-slash form (e.g. /blog).
 			if cv := ctx.App.lookupContent(pattern); cv != nil && cv.Title != "" {
+				title = cv.Title
+			} else if cv := ctx.App.lookupContent(pattern + "/{$}"); cv != nil && cv.Title != "" {
 				title = cv.Title
 			}
 		}


### PR DESCRIPTION
## Why

A site using `xun.WithContent("blog")` with a `blog/index.html` landing page
served the directory root at the wrong URL: instead of registering
`GET /blog/{$}`, the engine registered `GET /index`. The broken logic in
`loadContentPage` stripped the content-dir prefix (`blog/`) first, and only
then sliced `/index.html` off the remainder — but by then the remainder was
the bare string `index.html`, so `strings.TrimSuffix(rel, "/index.html")`
was a silent no-op. The result was a non-routable `GET /index` entry that
shadowed nothing and served nothing useful, and a `blog/` URL that 404'd.

The same shape existed on the `.md` side: `blog/index.md` registered as
`GET /blog/index` instead of `GET /blog/{$}`. That produced two SEO-visible
URLs for the same page — `/blog/index` and `/blog/` — and made every
breadcrumb-ancestor lookup that expected the canonical directory root
miss. The fix has to register both `index.html` and `index.md` at the
canonical `GET /<dir>/{$}` pattern that `loadPage` already produces for
`pages/<dir>/index.html`, so `http.ServeMux` 307-redirects the no-slash
form (`/blog` → `/blog/`) for free and crawlers only see one URL.

A related footgun lived in the hot-reload path: `FileChanged`'s `.md`
Remove branch derived the `contentViews` key from a `strings.TrimPrefix`
slug while `loadContentFile` derived it from the raw path, so on file
removal the two computations could drift and the route would leak until
restart. The PR forces both sites through a single helper so the stored
and deleted keys are identical by construction.

## What changed

- `loadContentPage` slice-trims `"index.html"` (10 chars) **before** the
  content-dir prefix strip, so the trailing `/` survives and `splitFile`
  expands the pattern to `/<dir>/{$}`. The dir-prefix strip then leaves
  the in-content path intact for non-index siblings.
- `loadContentFile` applies the symmetric treatment to `index.md` —
  strip `/index` and append `/` so `splitFile` also produces `/<dir>/{$}`.
- A new `contentPatternBase(mdPath)` helper centralises the `.md`
  pattern computation; both `loadContentFile` (on Create/Write) and
  `FileChanged`'s `.md` Remove branch go through it, so the stored and
  deleted `contentViews` keys are guaranteed identical.
- `buildBreadcrumb` falls back to `pattern + "/{$}"` when the
  URL-derived pattern misses, so directory-level H1s still resolve when
  the breadcrumb prefix is the no-slash form (e.g. `/blog`).
- `ContentView.Slug` intentionally keeps the literal `/index` segment
  (file-identity namespace); only the route URL (the `contentViews` map
  key) is canonicalised.

## Diff overview

- `viewengine_html.go` — reorders the slice-trim vs. prefix-strip in
  `loadContentPage`; routes the `.md` register and remove paths through
  the new `contentPatternBase` helper; doc-comments explain why the
  ordering matters and why both sites must share one key computation.
- `viewer_html.go` — adds the `/{$}` fallback in `buildBreadcrumb`'s
  title lookup so the URL-derived no-slash prefix still hits the
  canonical directory-root pattern.
- `docs/content.md` — Rule 1.2 and §3.4 step 4 now document the
  `index.md → /<dir>/{$}` special case and clarify that `Slug` is the
  file-identity namespace while the route URL is the map key.
- `content_test.go` — six new regression tests: `WithContent("blog") +
  blog/index.html` round-trip + 307 redirect from `/blog` to `/blog/`,
  nested default-dir `content/blog/index.html`, hot-reload of an
  `index.md`, `blog/index.md` with bubble-up template, `.md` Remove
  key parity, and an update to `TestContentTemplateAndPageCoexist`
  that pins the directory-level page at `GET /content/blog/{$}`.
- `viewer_breadcrumb_test.go` — `TestBuildBreadcrumbMarkdownAncestorCanonicalPattern`
  pins the `/{$}` fallback; `TestBreadcrumbEndToEndMarkdownIndexAncestor`
  is a full end-to-end check that a child post's breadcrumb carries
  the directory-level H1 from `blog/index.md` via the `WithContent("blog")`
  setup; existing breadcrumb tests are updated for the new key shape.

## Test evidence

- `go test ./...` runs clean on the branch (the full content + breadcrumb
  suite, including the six new regressions and the two updated existing
  tests, passes locally).
- Behavioural checks now pinned by tests:
  - `GET /blog/` serves `blog/index.html` directly with status 200.
  - `GET /blog` returns 307 with `Location: /blog/` (ServeMux's built-in
    redirect — no duplicate route, no duplicate-content SEO signal).
  - `app.routes` contains `GET /blog/{$}` and `GET /welcome`, and does
    **not** contain the old `GET /index` or the duplicate `GET /blog`.
  - Removing `content/blog/index.md` clears the `GET /content/blog/{$}`
    key in `contentViews` (no leak).
  - Breadcrumb on `/blog/2026/x` renders the directory-level H1
    (`博客首页`) on the `/blog` ancestor via the `WithContent("blog")`
    + `blog/index.md` setup.

Tests: `go test ./...` passes — new regressions cover both the
`WithContent(...) + index.html` shape and the default `content/ + index.md`
shape, plus the hot-reload key-parity and breadcrumb fallback.

Closes #120

## Summary by Sourcery

Canonicalize content directory index routes and keep related content views, breadcrumbs, and hot-reload behavior consistent.

Bug Fixes:
- Register content directory index pages at canonical trailing-slash routes, ensuring correct serving, redirects, and avoiding duplicate URLs.
- Keep content view keys consistent during markdown hot-reload removal so deleted index pages do not remain registered.
- Resolve directory-level content titles in breadcrumb ancestors through their canonical route patterns.

Enhancements:
- Preserve the literal index segment in content slugs while separating file identity from canonical routing semantics.

Documentation:
- Document canonical routing for index.md pages and clarify the distinction between ContentView slugs and route keys.

Tests:
- Add regression coverage for canonical index.html and index.md routes, redirects, hot reload behavior, content-view cleanup, and breadcrumb resolution.