### PR TITLE
chore(deps): bump github.com/go-playground/validator/v10 from 10.30.1 to 10.30.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-playground/form/v4 v4.3.0
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
-	github.com/go-playground/validator/v10 v10.30.1
+	github.com/go-playground/validator/v10 v10.30.3
 	github.com/stretchr/testify v1.12.1
 	github.com/yaitoo/async v1.0.4
 	github.com/yuin/goldmark v1.8.5
@@ -15,7 +15,7 @@ require (
 )
 
 require (
-	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/net v0.57.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/gabriel-vasile/mimetype v1.4.12 h1:e9hWvmLYvtp846tLHam2o++qitpguFiYCKbn0w9jyqw=
-github.com/gabriel-vasile/mimetype v1.4.12/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
+github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
+github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/form/v4 v4.3.0 h1:OVttojbQv2WNCs4P+VnjPtrt/+30Ipw4890W3OaFlvk=
@@ -8,8 +8,8 @@ github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/o
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
-github.com/go-playground/validator/v10 v10.30.1 h1:f3zDSN/zOma+w6+1Wswgd9fLkdwy06ntQJp0BBvFG0w=
-github.com/go-playground/validator/v10 v10.30.1/go.mod h1:oSuBIQzuJxL//3MelwSLD5hc2Tu889bF0Idm9Dg26cM=
+github.com/go-playground/validator/v10 v10.30.3 h1:4MU6YkEwx7GbcPJOZxrtbu+QfF3pJLJuaYTeAH0DYy8=
+github.com/go-playground/validator/v10 v10.30.3/go.mod h1:4Axh7oCNGcoGkqLoE4YWt6n20mcEIsPRlB7vPk3lpyc=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=


### PR DESCRIPTION
## Why
The `validator/v10` package is pinned to v10.30.1 in `go.mod` while theupstream module has shipped v10.30.3. That gap means we are missing the
bug fixes and validation-rule corrections accumulated between 10.30.1 and
10.30.3 (including the `isdefault`/`required` tag edge-case fixes shippedin those patch releases). Pulling the latest patch in keeps request
validation in `xun` aligned with upstream behaviour and avoids drift when
contributors run `go mod tidy` locally.

## What
- `github.com/go-playground/validator/v10` advanced from `v10.30.1` →
 `v10.30.3` in the direct `require` block.
- `github.com/gabriel-vasile/mimetype` advanced from `v1.4.12` →
  `v1.4.13` as an indirect dependency (pulled in by the validator
  bump).
- No application source under `internal/`, `cmd/`, or package roots
  changed; this is a manifest-only refresh.

## Diff overview
- `go.mod` — two-line bump: direct `validator/v10` requirement and
  indirect `gabriel-vasile/mimetype` requirement both advance by one
  patch version. Net effect: lockfile now points at the patched
  upstream releases.
- `go.sum` — corresponding checksum updates for both modules
  (4 lines added, 4 removed). Effect: `go mod verify` will succeed
  against the new hashes and the previous hashes are dropped.

## Test evidence
Tests: n/a — pure dependency manifest refresh. CI must be relied on to
re-resolve the graph (`go mod download` + `go mod verify`) and re-run
`go test ./...` against the new validator/mimetype pair; no local
`go test` invocation was performed as part of preparing this PR. If a
reviewer wants belt-and-braces evidence, run `go mod tidy && go test
./...` on a clean checkout — no code changes should be needed.

## Summary by Sourcery

Refresh validation dependencies to their latest patched releases.

Enhancements:
- Update github.com/go-playground/validator/v10 to v10.30.3 and its indirect mimetype dependency to v1.4.13 to incorporate upstream patch fixes and validation corrections.

Chores:
- Refresh go.sum checksums for the updated dependencies.