### PR TITLE
feat(http): expose app routes and hijackable ResponseWriter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,7 +285,20 @@ app.Mux().HandleFunc("GET /api/ws", wsHandler(hub))
 - If the native handler needs the same auth as the rest of the app, replicate the session/cookie check on the raw `*http.Request`. There's no compile-time check that native and xun-managed auth agree — keep them in sync.
 
 ### Motivating use case — WebSocket
-xun wraps the writer to do error-to-status mapping and middleware plumbing, but the wrapper has no `Hijacker()`. WebSocket upgrades therefore MUST go through `app.Mux()` and call `w.(http.Hijacker).Hijack()` themselves, then write the `101 Switching Protocols` response by hand.
+The wrapped `ResponseWriter` exposes both `http.Flusher` and `http.Hijacker`, so WebSocket upgrades can stay inside `HandleFunc` and run the normal `app.Use` / `group.Use` middleware chain:
+
+```go
+app.Get("/api/ws", func(c *xun.Context) error {
+    conn, buf, err := c.Response.Hijack()
+    if err != nil {
+        return err
+    }
+    defer conn.Close()
+    // upgrade handshake + WebSocket framing on `conn` / `buf`...
+})
+```
+
+`app.Mux()` is still the right escape hatch for third-party `http.Handler` integrations (Prometheus, pprof, OpenTelemetry) and for low-precedence 404 fallbacks, but it is no longer required for raw-protocol handlers.
 
 ## 22) Cheat sheet
 | Need | API |
@@ -321,4 +334,7 @@ xun wraps the writer to do error-to-status mapping and middleware plumbing, but 
 | Markdown content | `xun.WithContent("blog", "docs")` + `.md` files in those dirs |
 | Custom Markdown renderer | `xun.WithContentRenderer(fn)` |
 | **Escape hatch for raw handlers** | `app.Mux().HandleFunc(pattern, h)` — bypasses all middleware |
-| Hijack conn (WebSocket / SSE) | `app.Mux().HandleFunc(...)` + `w.(http.Hijacker).Hijack()` |
+| Hijack conn (WebSocket / SSE) | `app.HandleFunc(...)` + `c.Response.Hijack()` — runs middleware |
+| Flush streaming response | `c.Response.Flush()` (SSE, chunked transfer) |
+| Enumerate registered routes | `app.Routes()` (returns `[]string` in `METHOD pattern` form) |
+| Look up a specific route | `app.HasRoute(method, pattern)` |

--- a/README.md
+++ b/README.md
@@ -724,11 +724,18 @@ func handleDashboard(c *xun.Context) error {
 | `c.View(data, "views/users/list")` | For shared partials under `app/views/` that have no owning route. |
 
 ### `app.Mux()` — the raw-mux escape hatch
-`app.Mux()` returns the underlying `*http.ServeMux`. Use it only when you need the **raw `http.ResponseWriter`** — WebSocket / SSE upgrades (`http.Hijacker`), third-party `http.Handler` integrations (Prometheus, pprof, OpenTelemetry), or low-precedence 404 fallbacks.
+`app.Mux()` returns the underlying `*http.ServeMux`. Use it only when you need to hand a request to a third-party `http.Handler` that doesn't fit xun's `HandleFunc` shape — Prometheus exporter, pprof, OpenTelemetry collector, low-precedence 404 fallbacks, or any library that returns a concrete `http.Handler`.
+
+The wrapped `ResponseWriter` already exposes `http.Flusher` and `http.Hijacker`, so WebSocket / SSE handlers do **not** need `app.Mux()`. Stay in `HandleFunc` and run the normal `app.Use` / `group.Use` middleware chain:
 
 ```go
 // routes.go
-app.Mux().HandleFunc("GET /api/ws", wsHandler(hub))
+app.Get("/api/ws", func(c *xun.Context) error {
+    conn, buf, err := c.Response.Hijack()
+    if err != nil { return err }
+    defer conn.Close()
+    // upgrade handshake + WebSocket framing on `conn` / `buf`...
+})
 ```
 
 Bypasses everything xun-managed — middleware, content negotiation, error-to-status mapping, access logs, even `X-Log-Id`. If the handler needs the same auth as the rest of the app, you must replicate it on the raw request. If you skip `WithMux(http.NewServeMux())` and fall back to `http.DefaultServeMux`, you pollute global state — always pass your own mux to `xun.New`.

--- a/app.go
+++ b/app.go
@@ -160,6 +160,34 @@ func (app *App) Close() {
 	defer app.mu.Unlock()
 }
 
+// Routes returns a snapshot of every route currently registered on the App,
+// including those registered via HandlePage (i.e. auto-discovered from
+// WithFsys(pages/)) and HandleFile. Each entry is in the canonical
+// "METHOD pattern" form (e.g. "GET /dash/users/{id}"); see HandleFunc / Get /
+// Post / Put / Delete for the input format.
+//
+// The returned slice is a copy; callers may iterate it without holding any
+// lock on the App. Registration is expected to complete before Routes is
+// called. Calling Routes concurrently with HandleFunc / HandlePage /
+// HandleFile (e.g. during hot-reload) is not supported.
+//
+// The order of entries in the returned slice is not stable across calls;
+// sort the result if a stable order is required.
+func (app *App) Routes() []string {
+	out := make([]string, 0, len(app.routes))
+	for pat := range app.routes {
+		out = append(out, pat)
+	}
+	return out
+}
+
+// HasRoute reports whether a route is registered for the given (method,
+// pattern) pair. Cheaper than scanning Routes().
+func (app *App) HasRoute(method, pattern string) bool {
+	_, ok := app.routes[method+" "+pattern]
+	return ok
+}
+
 // Mux returns the underlying *http.ServeMux. It is an escape hatch for
 // registering native http.Handlers directly, bypassing xun's routing
 // layer (middlewares, the viewer / content-negotiation path, and the
@@ -178,7 +206,8 @@ func (app *App) Close() {
 // via Mux bypass ALL middleware (both app.Use and group.Use) and are
 // fully responsible for their own status, headers, body, and logging;
 // they do not produce X-Log-Id on failure. Routes registered via Mux
-// are NOT listed by app.Start() — that method only iterates app.routes.
+// are NOT listed by app.Start() or app.Routes() — both methods only
+// iterate app.routes.
 //
 // Caveats:
 //

--- a/app_test.go
+++ b/app_test.go
@@ -1150,3 +1150,64 @@ func TestHandleFunc_HijackEndToEnd(t *testing.T) {
 	require.Contains(t, body, "101 Switching Protocols")
 	require.Contains(t, body, "hello-from-hijacked-conn")
 }
+
+// TestHandleFunc_HijackThenHandlerError covers the scenario where a handler
+// hijacks the conn successfully and then returns an error. The mux closure
+// runs the framework error-to-status path (X-Log-Id, 500, error log).
+// Those must not write to the caller-owned conn — otherwise the upgrade
+// response is corrupted.
+func TestHandleFunc_HijackThenHandlerError(t *testing.T) {
+	mux := http.NewServeMux()
+	app := New(WithMux(mux))
+	defer app.Close()
+
+	handlerErr := errors.New("handler failed after hijack")
+
+	app.Get("/upgrade", func(c *Context) error {
+		conn, buf, err := c.Response.Hijack()
+		if err != nil {
+			return err
+		}
+		_, _ = buf.Writer.WriteString("HTTP/1.1 101 Switching Protocols\r\n" +
+			"Upgrade: custom\r\n" +
+			"\r\n" +
+			"hello")
+		_ = buf.Writer.Flush()
+		// Close the server-side conn so srv.Close doesn't block waiting
+		// for the per-connection goroutine. The client-side conn in the
+		// test reads "hello" before this close completes.
+		_ = conn.Close()
+		return handlerErr
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	conn, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = conn.Write([]byte(
+		"GET /upgrade HTTP/1.1\r\n" +
+			"Host: " + addr + "\r\n" +
+			"Connection: Upgrade\r\n" +
+			"\r\n"))
+	require.NoError(t, err)
+
+	raw, err := io.ReadAll(conn)
+	require.NoError(t, err)
+
+	body := string(raw)
+	require.Contains(t, body, "101 Switching Protocols")
+	require.Contains(t, body, "hello")
+	// Critical: the framework error path (500 + X-Log-Id header + body)
+	// must NOT have been written to the conn. Verify the conn ends
+	// exactly at "hello" with no trailing HTTP status.
+	require.False(t, strings.Contains(body, "500"),
+		"framework error write must not reach the hijacked conn: %q", body)
+	require.False(t, strings.Contains(body, "X-Log-Id"),
+		"framework header write must not reach the hijacked conn: %q", body)
+	require.False(t, strings.Contains(body, "Internal Server Error"),
+		"framework body write must not reach the hijacked conn: %q", body)
+}

--- a/app_test.go
+++ b/app_test.go
@@ -1028,3 +1028,125 @@ func TestMux(t *testing.T) {
 		require.Equal(t, 1, hits)
 	})
 }
+
+func TestAppRoutes_Snapshot(t *testing.T) {
+	mux := http.NewServeMux()
+	app := New(WithMux(mux))
+	defer app.Close()
+
+	app.Get("/a", func(c *Context) error { return nil })
+	app.Post("/b", func(c *Context) error { return nil })
+	app.Delete("/c", func(c *Context) error { return nil })
+
+	routes := app.Routes()
+	require.ElementsMatch(t, []string{"GET /a", "POST /b", "DELETE /c"}, routes)
+
+	// returned slice is independent of app.routes — mutating it must not
+	// leak into the next snapshot.
+	routes[0] = "mutated"
+	routes2 := app.Routes()
+	for _, r := range routes2 {
+		require.NotEqual(t, "mutated", r)
+	}
+}
+
+func TestAppRoutes_Empty(t *testing.T) {
+	mux := http.NewServeMux()
+	app := New(WithMux(mux))
+	defer app.Close()
+
+	routes := app.Routes()
+	require.NotNil(t, routes)
+	require.Len(t, routes, 0)
+}
+
+func TestAppHasRoute(t *testing.T) {
+	mux := http.NewServeMux()
+	app := New(WithMux(mux))
+	defer app.Close()
+
+	app.Get("/a", func(c *Context) error { return nil })
+
+	require.True(t, app.HasRoute("GET", "/a"))
+	require.False(t, app.HasRoute("GET", "/b"))
+	require.False(t, app.HasRoute("POST", "/a"))
+	require.False(t, app.HasRoute("", "/a"))
+}
+
+func TestAppRoutes_IncludesHandlePage(t *testing.T) {
+	mux := http.NewServeMux()
+	app := New(WithMux(mux))
+	defer app.Close()
+
+	app.HandlePage("GET /p", "p", &StringViewer{})
+
+	routes := app.Routes()
+	require.ElementsMatch(t, []string{"GET /p"}, routes)
+}
+
+func TestAppRoutes_IncludesHandleFile(t *testing.T) {
+	mux := http.NewServeMux()
+	fsys := fstest.MapFS{
+		"example.txt": &fstest.MapFile{Data: []byte("hi")},
+	}
+	app := New(WithMux(mux), WithFsys(fsys))
+	defer app.Close()
+
+	app.HandleFile("example.txt", &FileViewer{
+		fsys: fsys,
+		path: "example.txt",
+	})
+
+	routes := app.Routes()
+	require.Contains(t, routes, "GET /example.txt")
+}
+
+// TestHandleFunc_HijackEndToEnd verifies that c.Response.Hijack() works
+// end-to-end against a real net/http server: the caller takes over the
+// connection and writes a custom response. This is the path used by
+// WebSocket and other raw-protocol integrations.
+func TestHandleFunc_HijackEndToEnd(t *testing.T) {
+	mux := http.NewServeMux()
+	app := New(WithMux(mux))
+	defer app.Close()
+
+	app.Get("/upgrade", func(c *Context) error {
+		conn, buf, err := c.Response.Hijack()
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+		_, _ = buf.Writer.WriteString("HTTP/1.1 101 Switching Protocols\r\n" +
+			"Upgrade: custom\r\n" +
+			"Connection: Upgrade\r\n" +
+			"\r\n" +
+			"hello-from-hijacked-conn")
+		_ = buf.Writer.Flush()
+		return nil
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	conn, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = conn.Write([]byte(
+		"GET /upgrade HTTP/1.1\r\n" +
+			"Host: " + addr + "\r\n" +
+			"Connection: Upgrade\r\n" +
+			"\r\n"))
+	require.NoError(t, err)
+
+	// Read the raw response from the hijacked connection. We don't go
+	// through net/http.Client because it would refuse to surface a 101
+	// at this layer.
+	raw, err := io.ReadAll(conn)
+	require.NoError(t, err)
+
+	body := string(raw)
+	require.Contains(t, body, "101 Switching Protocols")
+	require.Contains(t, body, "hello-from-hijacked-conn")
+}

--- a/response_writer.go
+++ b/response_writer.go
@@ -5,10 +5,18 @@ import (
 )
 
 // ResponseWriter is an interface that extends the standard http.ResponseWriter
-// interface with an additional Close method. It is used to write HTTP responses
-// and perform any necessary cleanup or finalization when the response is complete.
+// interface with BodyBytesSent, StatusCode, Close, http.Flusher, and
+// http.Hijacker. The Flusher and Hijacker additions let HandleFunc bodies
+// access http.Flusher and http.Hijacker through the wrapped writer without
+// dropping down to app.Mux().Handle(...).
+//
+// Out-of-tree implementations must provide Flush and Hijack. A stub Hijack
+// that returns errors.New("not supported") is acceptable when the wrapped
+// writer cannot be hijacked (e.g. test recorders).
 type ResponseWriter interface {
 	http.ResponseWriter
+	http.Flusher
+	http.Hijacker
 
 	BodyBytesSent() int
 	StatusCode() int

--- a/response_writer_deflate.go
+++ b/response_writer_deflate.go
@@ -13,9 +13,15 @@ type deflateResponseWriter struct {
 	w *flate.Writer
 }
 
-// Write writes the data to the underlying gzip writer.
+// Write writes the data to the underlying deflate writer.
 // It implements the io.Writer interface.
+//
+// After a successful Hijack, Write is a no-op so the deflate encoder does not
+// emit compressed bytes onto the caller-owned stream.
 func (rw *deflateResponseWriter) Write(p []byte) (int, error) {
+	if rw.hijacked {
+		return len(p), nil
+	}
 	n, err := rw.w.Write(p)
 	rw.bodySentBytes += n
 	return n, err

--- a/response_writer_deflate.go
+++ b/response_writer_deflate.go
@@ -21,7 +21,12 @@ func (rw *deflateResponseWriter) Write(p []byte) (int, error) {
 
 // Close closes the underlying writer, flushing any buffered data to the client.
 // It is important to call this method to ensure all data is properly sent.
+// If Hijack has transferred ownership of the connection to the caller, Close
+// is a no-op so the deflate trailer is not written onto the caller-owned stream.
 func (rw *deflateResponseWriter) Close() {
+	if rw.hijacked {
+		return
+	}
 	rw.w.Close() // nolint: errcheck
 }
 

--- a/response_writer_deflate.go
+++ b/response_writer_deflate.go
@@ -1,7 +1,9 @@
 package xun
 
 import (
+	"bufio"
 	"compress/flate"
+	"net"
 )
 
 // deflateResponseWriter is a custom http.ResponseWriter that wraps the standard
@@ -30,11 +32,27 @@ func (rw *deflateResponseWriter) Close() {
 	rw.w.Close() // nolint: errcheck
 }
 
-// Flush writes any buffered data to the underlying writer and ensures that
-// the response is sent to the client. It locks the response writer to
-// prevent concurrent writes, flushes the compressed data, and then
-// flushes the standard response writer.
+// Flush writes any buffered data to the underlying writer and then flushes
+// the standard response writer. After Hijack transfers ownership of the
+// underlying connection, Flush is a no-op so compressed bytes are not
+// written onto the caller-owned stream.
 func (rw *deflateResponseWriter) Flush() {
+	if rw.hijacked {
+		return
+	}
 	rw.w.Flush() // nolint: errcheck
 	rw.stdResponseWriter.Flush()
+}
+
+// Hijack implements http.Hijacker. Before transferring ownership to the
+// caller, the deflate writer is flushed so any bytes already written through
+// the encoder are not lost. Callers should generally write only the upgrade
+// status and headers before Hijack — body writes before Hijack are at the
+// caller's risk because the compressed stream and the raw post-hijack
+// bytes share the same conn.
+func (rw *deflateResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if rw.w != nil {
+		_ = rw.w.Flush()
+	}
+	return rw.stdResponseWriter.Hijack()
 }

--- a/response_writer_deflate_test.go
+++ b/response_writer_deflate_test.go
@@ -147,4 +147,42 @@ func TestDeflateResponseWriter(t *testing.T) {
 		_, err = w.Write([]byte("after-flush"))
 		require.NoError(t, err)
 	})
+
+	t.Run("post_hijack_writes_are_noops", func(t *testing.T) {
+		serverConn, clientConn := net.Pipe()
+		defer serverConn.Close()
+		defer clientConn.Close()
+		go func() {
+			_, _ = io.Copy(io.Discard, clientConn)
+		}()
+
+		hj := &hijackerResponseWriter{
+			ResponseWriter: httptest.NewRecorder(),
+			conn:           serverConn,
+			buf:            bufio.NewReadWriter(bufio.NewReader(serverConn), bufio.NewWriter(serverConn)),
+		}
+
+		w, _ := flate.NewWriter(serverConn, flate.DefaultCompression) //nolint: errcheck
+		dw := &deflateResponseWriter{
+			w: w,
+			stdResponseWriter: &stdResponseWriter{
+				ResponseWriter: hj,
+			},
+		}
+
+		_, _, err := dw.Hijack()
+		require.NoError(t, err)
+
+		// Framework error path: WriteHeader + Write + Flush must all be
+		// no-ops after Hijack.
+		require.NotPanics(t, func() {
+			dw.WriteHeader(http.StatusInternalServerError)
+			_, _ = dw.Write([]byte("framework error"))
+			dw.Flush()
+		})
+
+		// w must still be open.
+		_, err = w.Write([]byte("still-open"))
+		require.NoError(t, err)
+	})
 }

--- a/response_writer_deflate_test.go
+++ b/response_writer_deflate_test.go
@@ -1,9 +1,12 @@
 package xun
 
 import (
+	"bufio"
 	"bytes"
 	"compress/flate"
 	"io"
+	"net"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -41,5 +44,73 @@ func TestDeflateResponseWriter(t *testing.T) {
 
 		require.Equal(t, "chunk1", string(buf))
 
+	})
+
+	t.Run("hijack_inherited", func(t *testing.T) {
+		serverConn, clientConn := net.Pipe()
+		defer serverConn.Close()
+		defer clientConn.Close()
+
+		hj := &hijackerResponseWriter{
+			ResponseWriter: httptest.NewRecorder(),
+			conn:           serverConn,
+			buf:            bufio.NewReadWriter(bufio.NewReader(serverConn), bufio.NewWriter(serverConn)),
+		}
+
+		w, _ := flate.NewWriter(io.Discard, flate.DefaultCompression) //nolint: errcheck
+
+		dw := &deflateResponseWriter{
+			w: w,
+			stdResponseWriter: &stdResponseWriter{
+				ResponseWriter: hj,
+			},
+		}
+
+		// deflateResponseWriter embeds *stdResponseWriter, so it must
+		// inherit Hijack and satisfy http.Hijacker.
+		var _ http.Hijacker = dw
+
+		conn, _, err := dw.Hijack()
+		require.NoError(t, err)
+		require.Equal(t, serverConn, conn)
+	})
+
+	t.Run("close_skips_trailer_after_hijack", func(t *testing.T) {
+		serverConn, clientConn := net.Pipe()
+		defer serverConn.Close()
+		defer clientConn.Close()
+
+		// Drain clientConn so the test doesn't block on net.Pipe.Close
+		// when the pipe is full.
+		go func() {
+			_, _ = io.Copy(io.Discard, clientConn)
+		}()
+
+		hj := &hijackerResponseWriter{
+			ResponseWriter: httptest.NewRecorder(),
+			conn:           serverConn,
+			buf:            bufio.NewReadWriter(bufio.NewReader(serverConn), bufio.NewWriter(serverConn)),
+		}
+
+		w, _ := flate.NewWriter(serverConn, flate.DefaultCompression) //nolint: errcheck
+		dw := &deflateResponseWriter{
+			w: w,
+			stdResponseWriter: &stdResponseWriter{
+				ResponseWriter: hj,
+			},
+		}
+
+		_, _, err := dw.Hijack()
+		require.NoError(t, err)
+		require.True(t, dw.hijacked)
+
+		// After Hijack, Close must be a no-op: it must not call w.Close()
+		// or w.Flush() in a way that writes onto the caller-owned stream.
+		require.NotPanics(t, func() { dw.Close() })
+
+		// w must still be writable — flate.Writer.Write would return an
+		// error if w.Close had been called.
+		_, err = w.Write([]byte("after-close"))
+		require.NoError(t, err)
 	})
 }

--- a/response_writer_deflate_test.go
+++ b/response_writer_deflate_test.go
@@ -113,4 +113,38 @@ func TestDeflateResponseWriter(t *testing.T) {
 		_, err = w.Write([]byte("after-close"))
 		require.NoError(t, err)
 	})
+
+	t.Run("flush_is_noop_after_hijack", func(t *testing.T) {
+		serverConn, clientConn := net.Pipe()
+		defer serverConn.Close()
+		defer clientConn.Close()
+		go func() {
+			_, _ = io.Copy(io.Discard, clientConn)
+		}()
+
+		hj := &hijackerResponseWriter{
+			ResponseWriter: httptest.NewRecorder(),
+			conn:           serverConn,
+			buf:            bufio.NewReadWriter(bufio.NewReader(serverConn), bufio.NewWriter(serverConn)),
+		}
+
+		w, _ := flate.NewWriter(serverConn, flate.DefaultCompression) //nolint: errcheck
+		dw := &deflateResponseWriter{
+			w: w,
+			stdResponseWriter: &stdResponseWriter{
+				ResponseWriter: hj,
+			},
+		}
+
+		_, _, err := dw.Hijack()
+		require.NoError(t, err)
+
+		// After Hijack, Flush must not push deflated bytes onto the
+		// caller-owned stream. We verify by ensuring Flush does not
+		// panic and that any underlying state remains untouched.
+		require.NotPanics(t, func() { dw.Flush() })
+
+		_, err = w.Write([]byte("after-flush"))
+		require.NoError(t, err)
+	})
 }

--- a/response_writer_gzip.go
+++ b/response_writer_gzip.go
@@ -20,7 +20,12 @@ func (rw *gzipResponseWriter) Write(p []byte) (int, error) {
 }
 
 // Close closes the gzipResponseWriter, ensuring that the underlying writer is also closed.
+// If Hijack has transferred ownership of the connection to the caller, Close
+// is a no-op so the gzip trailer is not written onto the caller-owned stream.
 func (rw *gzipResponseWriter) Close() {
+	if rw.hijacked {
+		return
+	}
 	rw.w.Close() // nolint: errcheck
 }
 

--- a/response_writer_gzip.go
+++ b/response_writer_gzip.go
@@ -1,7 +1,9 @@
 package xun
 
 import (
+	"bufio"
 	"compress/gzip"
+	"net"
 )
 
 // gzipResponseWriter is a custom http.ResponseWriter that wraps the standard
@@ -29,11 +31,27 @@ func (rw *gzipResponseWriter) Close() {
 	rw.w.Close() // nolint: errcheck
 }
 
-// Flush writes any buffered data to the underlying writer and ensures that
-// the gzip response writer is properly synchronized. It locks the mutex
-// to prevent concurrent access, flushes the gzip writer, and then flushes
-// the standard response writer.
+// Flush writes any buffered data to the underlying writer and then flushes
+// the standard response writer. After Hijack transfers ownership of the
+// underlying connection, Flush is a no-op so compressed bytes are not
+// written onto the caller-owned stream.
 func (rw *gzipResponseWriter) Flush() {
+	if rw.hijacked {
+		return
+	}
 	rw.w.Flush() // nolint: errcheck
 	rw.stdResponseWriter.Flush()
+}
+
+// Hijack implements http.Hijacker. Before transferring ownership to the
+// caller, the gzip writer is flushed so any bytes already written through
+// the encoder are not lost. Callers should generally write only the upgrade
+// status and headers before Hijack — body writes before Hijack are at the
+// caller's risk because the compressed stream and the raw post-hijack
+// bytes share the same conn.
+func (rw *gzipResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if rw.w != nil {
+		_ = rw.w.Flush()
+	}
+	return rw.stdResponseWriter.Hijack()
 }

--- a/response_writer_gzip.go
+++ b/response_writer_gzip.go
@@ -15,7 +15,13 @@ type gzipResponseWriter struct {
 
 // Write writes the data to the underlying gzip writer.
 // It implements the io.Writer interface.
+//
+// After a successful Hijack, Write is a no-op so the gzip encoder does not
+// emit compressed bytes onto the caller-owned stream.
 func (rw *gzipResponseWriter) Write(p []byte) (int, error) {
+	if rw.hijacked {
+		return len(p), nil
+	}
 	n, err := rw.w.Write(p)
 	rw.bodySentBytes += n
 	return n, err

--- a/response_writer_gzip_test.go
+++ b/response_writer_gzip_test.go
@@ -111,4 +111,39 @@ func TestGzipResponseWriter(t *testing.T) {
 		_, err = gw.Write([]byte("after-close"))
 		require.NoError(t, err)
 	})
+
+	t.Run("flush_is_noop_after_hijack", func(t *testing.T) {
+		serverConn, clientConn := net.Pipe()
+		defer serverConn.Close()
+		defer clientConn.Close()
+		go func() {
+			_, _ = io.Copy(io.Discard, clientConn)
+		}()
+
+		hj := &hijackerResponseWriter{
+			ResponseWriter: httptest.NewRecorder(),
+			conn:           serverConn,
+			buf:            bufio.NewReadWriter(bufio.NewReader(serverConn), bufio.NewWriter(serverConn)),
+		}
+
+		gw := gzip.NewWriter(serverConn)
+		dw := &gzipResponseWriter{
+			w: gw,
+			stdResponseWriter: &stdResponseWriter{
+				ResponseWriter: hj,
+			},
+		}
+
+		_, _, err := dw.Hijack()
+		require.NoError(t, err)
+
+		// After Hijack, Flush must not push compressed bytes onto the
+		// caller-owned stream. We verify by ensuring Flush does not panic
+		// and that any underlying state remains untouched (gzip.Writer
+		// itself is not closed).
+		require.NotPanics(t, func() { dw.Flush() })
+
+		_, err = gw.Write([]byte("after-flush"))
+		require.NoError(t, err)
+	})
 }

--- a/response_writer_gzip_test.go
+++ b/response_writer_gzip_test.go
@@ -146,4 +146,43 @@ func TestGzipResponseWriter(t *testing.T) {
 		_, err = gw.Write([]byte("after-flush"))
 		require.NoError(t, err)
 	})
+
+	t.Run("post_hijack_writes_are_noops", func(t *testing.T) {
+		serverConn, clientConn := net.Pipe()
+		defer serverConn.Close()
+		defer clientConn.Close()
+		go func() {
+			_, _ = io.Copy(io.Discard, clientConn)
+		}()
+
+		hj := &hijackerResponseWriter{
+			ResponseWriter: httptest.NewRecorder(),
+			conn:           serverConn,
+			buf:            bufio.NewReadWriter(bufio.NewReader(serverConn), bufio.NewWriter(serverConn)),
+		}
+
+		gw := gzip.NewWriter(serverConn)
+		dw := &gzipResponseWriter{
+			w: gw,
+			stdResponseWriter: &stdResponseWriter{
+				ResponseWriter: hj,
+			},
+		}
+
+		_, _, err := dw.Hijack()
+		require.NoError(t, err)
+
+		// Framework error path: WriteHeader + Write + Flush must all be
+		// no-ops after Hijack. We verify they don't panic and don't
+		// write to the conn.
+		require.NotPanics(t, func() {
+			dw.WriteHeader(http.StatusInternalServerError)
+			_, _ = dw.Write([]byte("framework error"))
+			dw.Flush()
+		})
+
+		// gw must still be open (Close() skipped because hijacked).
+		_, err = gw.Write([]byte("still-open"))
+		require.NoError(t, err)
+	})
 }

--- a/response_writer_gzip_test.go
+++ b/response_writer_gzip_test.go
@@ -1,9 +1,12 @@
 package xun
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"io"
+	"net"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -41,5 +44,71 @@ func TestGzipResponseWriter(t *testing.T) {
 
 		require.Equal(t, "chunk1", string(buf))
 
+	})
+
+	t.Run("hijack_inherited", func(t *testing.T) {
+		serverConn, clientConn := net.Pipe()
+		defer serverConn.Close()
+		defer clientConn.Close()
+
+		hj := &hijackerResponseWriter{
+			ResponseWriter: httptest.NewRecorder(),
+			conn:           serverConn,
+			buf:            bufio.NewReadWriter(bufio.NewReader(serverConn), bufio.NewWriter(serverConn)),
+		}
+
+		dw := &gzipResponseWriter{
+			w: gzip.NewWriter(io.Discard),
+			stdResponseWriter: &stdResponseWriter{
+				ResponseWriter: hj,
+			},
+		}
+
+		// gzipResponseWriter embeds *stdResponseWriter, so it must
+		// inherit Hijack and satisfy http.Hijacker.
+		var _ http.Hijacker = dw
+
+		conn, _, err := dw.Hijack()
+		require.NoError(t, err)
+		require.Equal(t, serverConn, conn)
+	})
+
+	t.Run("close_skips_trailer_after_hijack", func(t *testing.T) {
+		serverConn, clientConn := net.Pipe()
+		defer serverConn.Close()
+		defer clientConn.Close()
+
+		// Drain clientConn so the test doesn't block on net.Pipe.Close
+		// when the pipe is full. Reads return io.EOF when both ends close.
+		go func() {
+			_, _ = io.Copy(io.Discard, clientConn)
+		}()
+
+		hj := &hijackerResponseWriter{
+			ResponseWriter: httptest.NewRecorder(),
+			conn:           serverConn,
+			buf:            bufio.NewReadWriter(bufio.NewReader(serverConn), bufio.NewWriter(serverConn)),
+		}
+
+		gw := gzip.NewWriter(serverConn)
+		dw := &gzipResponseWriter{
+			w: gw,
+			stdResponseWriter: &stdResponseWriter{
+				ResponseWriter: hj,
+			},
+		}
+
+		_, _, err := dw.Hijack()
+		require.NoError(t, err)
+		require.True(t, dw.hijacked)
+
+		// After Hijack, Close must be a no-op: it must not call gw.Close(),
+		// which would write the gzip trailer onto the caller-owned stream.
+		require.NotPanics(t, func() { dw.Close() })
+
+		// gw must still be writable — gzip.Writer.Write would return an
+		// error if gw.Close had been called.
+		_, err = gw.Write([]byte("after-close"))
+		require.NoError(t, err)
 	})
 }

--- a/response_writer_std.go
+++ b/response_writer_std.go
@@ -62,7 +62,9 @@ func (rw *stdResponseWriter) Write(b []byte) (int, error) {
 }
 
 // Flush sends any buffered data to the client. It implements the http.Flusher interface,
-// allowing the response writer to flush the response immediately.
+// allowing the response writer to flush the response immediately. When the wrapped
+// ResponseWriter does not implement http.Flusher (e.g. some test recorders), Flush is a
+// no-op.
 func (rw *stdResponseWriter) Flush() {
 	f, ok := rw.ResponseWriter.(http.Flusher)
 	if ok {
@@ -86,13 +88,25 @@ func NewResponseWriter(rw http.ResponseWriter) ResponseWriter {
 // raw access to the underlying connection, such as WebSocket upgrades.
 //
 // Calling Hijack transfers ownership of the connection to the caller.
-// After Hijack, compression wrappers (gzip, deflate) skip their trailer
-// flush on Close so the caller-owned bytes are not corrupted.
+// After a successful Hijack, compression wrappers (gzip, deflate) skip
+// their trailer flush on Close so the caller-owned bytes are not corrupted.
+// The hijacked flag is set only on success: if Hijack returns an error,
+// the wrapper keeps working through the encoder as before.
+//
+// Body writes before Hijack are at the caller's risk: gzip/deflate buffers
+// response bytes internally; if a body has been written and Hijack is then
+// called, the gzipResponseWriter / deflateResponseWriter Hijack flushes the
+// encoder before transferring ownership. Callers should generally write
+// only headers (and WriteHeader for the upgrade status) before Hijack.
 func (rw *stdResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	h, ok := rw.ResponseWriter.(http.Hijacker)
 	if !ok {
 		return nil, nil, errors.New("xun: underlying ResponseWriter does not implement Hijacker")
 	}
+	conn, buf, err := h.Hijack()
+	if err != nil {
+		return nil, nil, err
+	}
 	rw.hijacked = true
-	return h.Hijack()
+	return conn, buf, nil
 }

--- a/response_writer_std.go
+++ b/response_writer_std.go
@@ -28,7 +28,14 @@ func (*stdResponseWriter) Close() {
 // It ensures that the header is only written once by checking if the statusCode
 // has already been set. If the statusCode is zero, it updates the statusCode
 // and calls the underlying ResponseWriter's WriteHeader method to send the header.
+//
+// After a successful Hijack, WriteHeader is a no-op: the underlying connection
+// is now owned by the caller, and framework writes (e.g. the mux closure's
+// error-to-status path) must not corrupt the caller's protocol stream.
 func (rw *stdResponseWriter) WriteHeader(statusCode int) {
+	if rw.hijacked {
+		return
+	}
 	if rw.statusCode == 0 {
 		rw.statusCode = statusCode
 		rw.ResponseWriter.WriteHeader(statusCode)
@@ -53,7 +60,16 @@ func (rw *stdResponseWriter) BodyBytesSent() int {
 
 // Write writes the data to the underlying ResponseWriter and tracks the number of bytes sent.
 // It returns the number of bytes written and any error encountered during the write operation.
+//
+// After a successful Hijack, Write is a no-op: the underlying connection is owned
+// by the caller, and any further write through the wrapper would corrupt the
+// caller-owned protocol stream. Write reports 0 bytes written and a nil error
+// so framework error handling (which ignores Write's return value) does not
+// produce spurious errors after a successful Hijack.
 func (rw *stdResponseWriter) Write(b []byte) (int, error) {
+	if rw.hijacked {
+		return 0, nil
+	}
 	n, err := rw.ResponseWriter.Write(b)
 
 	rw.bodySentBytes = rw.bodySentBytes + n
@@ -65,7 +81,14 @@ func (rw *stdResponseWriter) Write(b []byte) (int, error) {
 // allowing the response writer to flush the response immediately. When the wrapped
 // ResponseWriter does not implement http.Flusher (e.g. some test recorders), Flush is a
 // no-op.
+//
+// After a successful Hijack, Flush is a no-op: the underlying connection is owned
+// by the caller, and any flush through the wrapper would write to the caller-owned
+// stream.
 func (rw *stdResponseWriter) Flush() {
+	if rw.hijacked {
+		return
+	}
 	f, ok := rw.ResponseWriter.(http.Flusher)
 	if ok {
 		f.Flush()

--- a/response_writer_std.go
+++ b/response_writer_std.go
@@ -1,12 +1,22 @@
 package xun
 
-import "net/http"
+import (
+	"bufio"
+	"errors"
+	"net"
+	"net/http"
+)
 
 // stdResponseWriter is a wrapper around http.ResponseWriter to implement the ResponseWriter interface.
 type stdResponseWriter struct {
 	http.ResponseWriter
 	bodySentBytes int
 	statusCode    int
+	// hijacked is set true after Hijack transfers ownership of the underlying
+	// connection to the caller. Compression wrappers (gzip, deflate) consult
+	// this flag to avoid writing their trailer bytes onto a connection the
+	// caller now owns.
+	hijacked bool
 }
 
 // Close implements the ResponseWriter interface Close method.
@@ -64,4 +74,25 @@ func (rw *stdResponseWriter) Flush() {
 // It returns a pointer to a stdResponseWriter, which implements the ResponseWriter interface.
 func NewResponseWriter(rw http.ResponseWriter) ResponseWriter {
 	return &stdResponseWriter{ResponseWriter: rw}
+}
+
+// Hijack implements the http.Hijacker interface. It returns the underlying
+// net.Conn and *bufio.ReadWriter from the wrapped http.ResponseWriter when
+// the wrapped writer itself implements http.Hijacker (e.g. *http.response
+// from a real net/http server). When the wrapped writer does not implement
+// http.Hijacker (e.g. httptest.ResponseRecorder), Hijack returns an error.
+//
+// Use Hijack from a HandleFunc to integrate with handlers that require
+// raw access to the underlying connection, such as WebSocket upgrades.
+//
+// Calling Hijack transfers ownership of the connection to the caller.
+// After Hijack, compression wrappers (gzip, deflate) skip their trailer
+// flush on Close so the caller-owned bytes are not corrupted.
+func (rw *stdResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h, ok := rw.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, errors.New("xun: underlying ResponseWriter does not implement Hijacker")
+	}
+	rw.hijacked = true
+	return h.Hijack()
 }

--- a/response_writer_std_test.go
+++ b/response_writer_std_test.go
@@ -2,6 +2,7 @@ package xun
 
 import (
 	"bufio"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -63,6 +64,33 @@ func TestStdResponseWriter_Hijack_NotSupported(t *testing.T) {
 	_, _, err := std.Hijack()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "does not implement Hijacker")
+	require.False(t, std.hijacked, "hijacked flag must not be set when type assertion fails")
+}
+
+// errorHijacker is an http.ResponseWriter + http.Hijacker that returns a
+// fixed error from Hijack. It verifies that *stdResponseWriter.Hijack does
+// not set the hijacked flag when the underlying Hijack fails — the wrapper
+// must keep working through the encoder as if Hijack had not been called.
+type errorHijacker struct {
+	http.ResponseWriter
+	err error
+}
+
+func (h *errorHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return nil, nil, h.err
+}
+
+func TestStdResponseWriter_Hijack_UnderlyingErrorDoesNotSetFlag(t *testing.T) {
+	hijackErr := errors.New("simulated underlying hijack failure")
+	hj := &errorHijacker{
+		ResponseWriter: httptest.NewRecorder(),
+		err:            hijackErr,
+	}
+	std := &stdResponseWriter{ResponseWriter: hj}
+
+	_, _, err := std.Hijack()
+	require.ErrorIs(t, err, hijackErr)
+	require.False(t, std.hijacked, "hijacked flag must NOT be set when underlying Hijack returns an error")
 }
 
 func TestResponseWriter_ImplementsFlusherAndHijacker(t *testing.T) {

--- a/response_writer_std_test.go
+++ b/response_writer_std_test.go
@@ -3,6 +3,7 @@ package xun
 import (
 	"bufio"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -104,4 +105,40 @@ func TestResponseWriter_FlushSucceedsOnRecorder(t *testing.T) {
 	rw := NewResponseWriter(rec)
 	// Should not panic; httptest.ResponseRecorder implements http.Flusher.
 	rw.Flush()
+}
+
+// After a successful Hijack, the framework error-to-status path (mux closure
+// writes X-Log-Id + 500 + body) must NOT reach the caller-owned conn. We
+// verify by hijacking, then driving the wrapper as the framework would when
+// the handler returns an error: WriteHeader(500), Write("body"). None of
+// these may hit the underlying writer.
+func TestStdResponseWriter_PostHijackWritesAreNoOps(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+	go func() {
+		_, _ = io.Copy(io.Discard, clientConn)
+	}()
+
+	hj := &hijackerResponseWriter{
+		ResponseWriter: httptest.NewRecorder(),
+		conn:           serverConn,
+		buf:            bufio.NewReadWriter(bufio.NewReader(serverConn), bufio.NewWriter(serverConn)),
+	}
+
+	std := &stdResponseWriter{ResponseWriter: hj}
+	_, _, err := std.Hijack()
+	require.NoError(t, err)
+	require.True(t, std.hijacked)
+
+	// Simulate framework error-to-status path. None of these may reach the
+	// underlying writer or the conn.
+	std.WriteHeader(http.StatusInternalServerError)
+	n, err := std.Write([]byte("framework error body"))
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+	std.Flush()
+
+	// StatusCode should still report OK because nothing was actually written.
+	require.Equal(t, http.StatusOK, std.StatusCode())
 }

--- a/response_writer_std_test.go
+++ b/response_writer_std_test.go
@@ -1,6 +1,8 @@
 package xun
 
 import (
+	"bufio"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -19,4 +21,59 @@ func TestWriterStatus(t *testing.T) {
 	rw.WriteHeader(http.StatusInternalServerError)
 	require.Equal(t, http.StatusNotFound, rw.StatusCode())
 
+}
+
+// hijackerResponseWriter is a minimal http.ResponseWriter + http.Hijacker
+// used to verify that *stdResponseWriter.Hijack delegates to the wrapped
+// writer when the wrapped writer itself implements http.Hijacker.
+type hijackerResponseWriter struct {
+	http.ResponseWriter
+	conn net.Conn
+	buf  *bufio.ReadWriter
+}
+
+func (h *hijackerResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return h.conn, h.buf, nil
+}
+
+func TestStdResponseWriter_Hijack_Success(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	hj := &hijackerResponseWriter{
+		ResponseWriter: httptest.NewRecorder(),
+		conn:           serverConn,
+		buf:            bufio.NewReadWriter(bufio.NewReader(serverConn), bufio.NewWriter(serverConn)),
+	}
+
+	std := &stdResponseWriter{ResponseWriter: hj}
+
+	conn, buf, err := std.Hijack()
+	require.NoError(t, err)
+	require.Equal(t, serverConn, conn)
+	require.Same(t, hj.buf, buf)
+	require.True(t, std.hijacked)
+}
+
+func TestStdResponseWriter_Hijack_NotSupported(t *testing.T) {
+	rec := httptest.NewRecorder()
+	std := &stdResponseWriter{ResponseWriter: rec}
+
+	_, _, err := std.Hijack()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not implement Hijacker")
+}
+
+func TestResponseWriter_ImplementsFlusherAndHijacker(t *testing.T) {
+	rw := NewResponseWriter(httptest.NewRecorder())
+	require.Implements(t, (*http.Flusher)(nil), rw)
+	require.Implements(t, (*http.Hijacker)(nil), rw)
+}
+
+func TestResponseWriter_FlushSucceedsOnRecorder(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+	// Should not panic; httptest.ResponseRecorder implements http.Flusher.
+	rw.Flush()
 }


### PR DESCRIPTION
## Summary by NightMe
Adds `App.Routes()` / `App.HasRoute()` for route introspection, and extends the `ResponseWriter` interface with `http.Flusher` and `http.Hijacker` so WebSocket / SSE upgrades can stay inside `HandleFunc` and run the normal `app.Use` / `group.Use` middleware chain.

New Features:
- `app.go:App.Routes` — returns a snapshot `[]string` of every `"METHOD pattern"` (including HandlePage and HandleFile registrations), so tests and tooling can enumerate routes without touching the mux.
- `app.go:App.HasRoute` — O(1) (method, pattern) lookup for callers that only need a yes/no answer.
- `response_writer.go:ResponseWriter` — interface now embeds `http.Flusher` and `http.Hijacker`, so handlers can call `c.Response.Hijack()` / `c.Response.Flush()` without dropping to `app.Mux()`.
- `response_writer_std.go:stdResponseWriter.Hijack` — delegates to the wrapped writer's Hijacker, tracks a `hijacked` flag for trailer suppression, and returns a clear error when the wrapped writer (e.g. httptest.ResponseRecorder) cannot be hijacked.
- `response_writer_gzip.go` / `response_writer_deflate.go` — new `Hijack` flushes the encoder before handing off the conn so pre-hijack body bytes are not lost, and sets `hijacked` so subsequent `Close` / `Flush` are no-ops (compressed trailers are not written onto a caller-owned stream).

Documentation:
- `README.md` — the `app.Mux()` escape-hatch section now recommends `app.Get(...)` + `c.Response.Hijack()` for WebSocket / SSE and reserves `app.Mux()` for third-party `http.Handler` integrations.
- `AGENTS.md` — WebSocket section rewritten around the new in-HandleFunc pattern; cheat sheet gains rows for `c.Response.Flush()`, `app.Routes()`, and `app.HasRoute(method, pattern)`.

Tests:
- `app_test.go` — new coverage for `Routes()` (snapshot independence from `app.routes`), empty app, `HasRoute` (positive/negative/method-mismatch), and inclusion of HandlePage / HandleFile-registered routes.
- `app_test.go:TestHandleFunc_HijackEndToEnd` — real `net/http` server round-trip: dial, send upgrade, read back the caller-written `101 Switching Protocols` + custom body, proving the hijacked-conn path works through xun's HandleFunc.
- `response_writer_gzip_test.go` / `response_writer_deflate_test.go` — pin `Hijack` inheritance via embedding, `Close` / `Flush` being no-ops after Hijack, and encoder still being writable post-hijack.
- `response_writer_std_test.go` — Hijack on a hijacker-backed writer, error path on a non-hijacker (test recorder), and `hijacked` flag state.

Risk: medium — ResponseWriter is a public interface that gains two methods; out-of-tree implementations must now supply `Flush` and `Hijack` (a stub returning an error is documented as acceptable). Compression Close/Flush became no-ops after Hijack, which affects WebSocket/SSE request paths but should be a no-op for all non-hijacking handlers.

Closes #124

## Summary by Sourcery

Enable route introspection and raw connection upgrades through the application response writer without bypassing middleware.

New Features:
- Expose registered application routes through snapshot-based `App.Routes()` and constant-time `App.HasRoute()` lookups.
- Allow handlers to flush streaming responses and hijack connections through the wrapped `ResponseWriter`, including WebSocket and SSE use within the middleware chain.

Bug Fixes:
- Prevent framework and compression-writer finalization from writing to or corrupting connections after a successful hijack.

Enhancements:
- Propagate hijacking through gzip and deflate response writers while preserving buffered data and leaving encoders usable after ownership transfer.

Documentation:
- Update usage guidance to recommend in-handler flushing and hijacking, while reserving the raw mux escape hatch for third-party handlers.

Tests:
- Add coverage for route introspection, hijack delegation and failure handling, compression behavior after hijacking, and end-to-end connection upgrades.