### PR TITLE
perf(compressor): pool gzip and flate writers across requests

### DIFF
--- a/compressor_deflate.go
+++ b/compressor_deflate.go
@@ -2,11 +2,28 @@ package xun
 
 import (
 	"compress/flate"
+	"io"
 	"net/http"
+	"sync"
 )
 
 // DeflateCompressor is a struct that provides functionality for compressing data using the DEFLATE algorithm.
 type DeflateCompressor struct {
+}
+
+// deflateWriterPool recycles *flate.Writer across requests. A fresh
+// flate.Writer at DefaultCompression carries a ~256 KiB deflate state;
+// allocating it per request dominated the GC profile of compressed apps.
+// The pool is goroutine-safe: each pooled encoder is bound to a single
+// request between Get and Put, and Reset on Get / Put drops any residual
+// reference to the previous ResponseWriter.
+var deflateWriterPool = sync.Pool{
+	New: func() any {
+		// DefaultCompression is a valid compression level; flate.NewWriter
+		// only errors when the level is out of range.
+		w, _ := flate.NewWriter(io.Discard, flate.DefaultCompression) //nolint: errcheck
+		return w
+	},
 }
 
 // AcceptEncoding returns the encoding type that the DeflateCompressor supports.
@@ -16,11 +33,16 @@ func (c *DeflateCompressor) AcceptEncoding() string {
 }
 
 // New creates a new deflateResponseWriter that wraps the provided http.ResponseWriter.
-// It sets the "Content-Encoding" header to "deflate" and initializes a flate.Writer
-// with the default compression level.
+// It sets the "Content-Encoding" header to "deflate" and binds a flate.Writer
+// (acquired from deflateWriterPool) to the underlying writer.
+//
+// The *flate.Writer is reused via Reset on every call, so the ~256 KiB
+// deflate state at DefaultCompression is recycled across requests instead
+// of being reallocated on every compressed response.
 func (c *DeflateCompressor) New(rw http.ResponseWriter) ResponseWriter {
 	rw.Header().Set("Content-Encoding", "deflate")
-	w, _ := flate.NewWriter(rw, flate.DefaultCompression) //nolint: errcheck because flate.DefaultCompression is a valid compression level
+	w := deflateWriterPool.Get().(*flate.Writer)
+	w.Reset(rw)
 
 	return &deflateResponseWriter{
 		w: w,

--- a/compressor_deflate.go
+++ b/compressor_deflate.go
@@ -12,11 +12,12 @@ type DeflateCompressor struct {
 }
 
 // deflateWriterPool recycles *flate.Writer across requests. A fresh
-// flate.Writer at DefaultCompression carries a ~256 KiB deflate state;
-// allocating it per request dominated the GC profile of compressed apps.
-// The pool is goroutine-safe: each pooled encoder is bound to a single
-// request between Get and Put, and Reset on Get / Put drops any residual
-// reference to the previous ResponseWriter.
+// flate.Writer at DefaultCompression carries a 64 KiB sliding window plus
+// an up-to-320 KiB fast-encoder history buffer (~384 KiB total).
+// Allocating that state per request dominated the GC profile of
+// compressed apps. The pool is goroutine-safe: each pooled encoder is
+// bound to a single request between Get and Put, and Reset on Get / Put
+// drops any residual reference to the previous ResponseWriter.
 var deflateWriterPool = sync.Pool{
 	New: func() any {
 		// DefaultCompression is a valid compression level; flate.NewWriter
@@ -36,9 +37,10 @@ func (c *DeflateCompressor) AcceptEncoding() string {
 // It sets the "Content-Encoding" header to "deflate" and binds a flate.Writer
 // (acquired from deflateWriterPool) to the underlying writer.
 //
-// The *flate.Writer is reused via Reset on every call, so the ~256 KiB
-// deflate state at DefaultCompression is recycled across requests instead
-// of being reallocated on every compressed response.
+// The *flate.Writer is reused via Reset on every call. Reset rebinds the
+// destination io.Writer and clears the deflate state, so the 64 KiB
+// sliding window and fast-encoder history buffer are recycled across
+// requests instead of being reallocated on every compressed response.
 func (c *DeflateCompressor) New(rw http.ResponseWriter) ResponseWriter {
 	rw.Header().Set("Content-Encoding", "deflate")
 	w := deflateWriterPool.Get().(*flate.Writer)

--- a/compressor_deflate_test.go
+++ b/compressor_deflate_test.go
@@ -116,12 +116,19 @@ func TestDeflateCompressor_DoubleClose(t *testing.T) {
 	// idempotency the *flate.Writer would be Put into deflateWriterPool
 	// twice, letting two concurrent Gets hand the same pointer to two
 	// requests and corrupt shared deflate state across them.
+	//
+	// The same scenario also exercises the post-Close surface: a
+	// wrapper that has been closed (and therefore has fw.w == nil)
+	// must not panic on subsequent Write or Flush calls.
 	c := &DeflateCompressor{}
 
 	rw := httptest.NewRecorder()
 	rw.Header().Set("Content-Encoding", "deflate")
 	w := c.New(rw)
 	fw := w.(*deflateResponseWriter)
+
+	_, err := fw.Write([]byte("before-close"))
+	require.NoError(t, err)
 
 	w.Close()
 	require.True(t, fw.closed, "first Close must set the closed flag")
@@ -134,6 +141,22 @@ func TestDeflateCompressor_DoubleClose(t *testing.T) {
 	require.NotPanics(t, func() { w.Close() })
 	require.Equal(t, bodyLenAfterFirst, rw.Body.Len(),
 		"second Close must not write additional bytes to the recorder")
+
+	// Post-Close Write must not panic on the nil rw.w and must not
+	// pull a fresh encoder out of the pool into a half-closed
+	// wrapper. It returns (len(p), nil), matching the post-Hijack
+	// no-op convention.
+	require.NotPanics(t, func() {
+		n, err := w.Write([]byte("after-close"))
+		require.NoError(t, err)
+		require.Equal(t, len("after-close"), n)
+	})
+
+	// Post-Close Flush must not panic on the nil rw.w.
+	require.NotPanics(t, func() { w.Flush() })
+
+	require.Equal(t, bodyLenAfterFirst, rw.Body.Len(),
+		"post-Close Write/Flush must not write to the recorder")
 }
 
 func TestDeflateCompressor_PoolAllocations(t *testing.T) {

--- a/compressor_deflate_test.go
+++ b/compressor_deflate_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -107,4 +108,77 @@ func TestDeflateCompressor(t *testing.T) {
 		})
 	}
 
+}
+
+func TestDeflateCompressor_PoolAllocations(t *testing.T) {
+	// See TestGzipCompressor_PoolAllocations for rationale. We
+	// deliberately do not assert Same-pointer identity between two
+	// Get calls: sync.Pool makes no LIFO guarantee and may evict the
+	// encoder between Put and Get under GC pressure (notably under
+	// -race). The AllocsPerRun signal is reliable across 1000
+	// iterations.
+
+	c := &DeflateCompressor{}
+
+	// Warmup: prime the local pool.
+	rw := httptest.NewRecorder()
+	rw.Header().Set("Content-Encoding", "deflate")
+	w := c.New(rw)
+	w.Close()
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		rw := httptest.NewRecorder()
+		rw.Header().Set("Content-Encoding", "deflate")
+		w := c.New(rw)
+		w.Close()
+	})
+
+	require.Less(t, allocs, 20.0,
+		"expected deflate encoder pooling to be active, but allocations per run were %.1f", allocs)
+}
+
+func BenchmarkDeflateCompressor(b *testing.B) {
+	fsys := fstest.MapFS{
+		"public/skin.css": {Data: []byte(strings.Repeat("body { color: red; }\n", 64))},
+	}
+
+	m := http.NewServeMux()
+	srv := httptest.NewServer(m)
+	defer srv.Close()
+
+	app := New(WithMux(m), WithFsys(fsys), WithCompressor(&DeflateCompressor{}))
+	defer app.Close()
+
+	app.Get("/payload", func(c *Context) error {
+		return c.View("payload body")
+	})
+
+	go app.Start()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/payload", nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	req.Header.Set("Accept-Encoding", "deflate")
+
+	// Warmup: prime the pool and HTTP transport before measuring.
+	for i := 0; i < 10; i++ {
+		resp, err := client.Do(req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resp, err := client.Do(req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
 }

--- a/compressor_deflate_test.go
+++ b/compressor_deflate_test.go
@@ -110,6 +110,32 @@ func TestDeflateCompressor(t *testing.T) {
 
 }
 
+func TestDeflateCompressor_DoubleClose(t *testing.T) {
+	// Close must be idempotent. A handler that calls c.Response.Close()
+	// plus the framework's defer also call Close(); without
+	// idempotency the *flate.Writer would be Put into deflateWriterPool
+	// twice, letting two concurrent Gets hand the same pointer to two
+	// requests and corrupt shared deflate state across them.
+	c := &DeflateCompressor{}
+
+	rw := httptest.NewRecorder()
+	rw.Header().Set("Content-Encoding", "deflate")
+	w := c.New(rw)
+	fw := w.(*deflateResponseWriter)
+
+	w.Close()
+	require.True(t, fw.closed, "first Close must set the closed flag")
+	require.Nil(t, fw.w, "first Close must release the encoder pointer")
+
+	bodyLenAfterFirst := rw.Body.Len()
+
+	// Second Close must not panic, must not write to the recorder,
+	// must not re-Put the encoder.
+	require.NotPanics(t, func() { w.Close() })
+	require.Equal(t, bodyLenAfterFirst, rw.Body.Len(),
+		"second Close must not write additional bytes to the recorder")
+}
+
 func TestDeflateCompressor_PoolAllocations(t *testing.T) {
 	// See TestGzipCompressor_PoolAllocations for rationale. We
 	// deliberately do not assert Same-pointer identity between two
@@ -138,19 +164,21 @@ func TestDeflateCompressor_PoolAllocations(t *testing.T) {
 }
 
 func BenchmarkDeflateCompressor(b *testing.B) {
-	fsys := fstest.MapFS{
-		"public/skin.css": {Data: []byte(strings.Repeat("body { color: red; }\n", 64))},
-	}
+	// 16 KiB of compressible-but-not-trivial payload — typical for a
+	// JSON/HTML response where the encoder's deflate state actually
+	// does work, and where the per-request encoder allocation would
+	// dominate without pooling.
+	payload := strings.Repeat("the quick brown fox jumps over the lazy dog\n", 380)
 
 	m := http.NewServeMux()
 	srv := httptest.NewServer(m)
 	defer srv.Close()
 
-	app := New(WithMux(m), WithFsys(fsys), WithCompressor(&DeflateCompressor{}))
+	app := New(WithMux(m), WithCompressor(&DeflateCompressor{}))
 	defer app.Close()
 
 	app.Get("/payload", func(c *Context) error {
-		return c.View("payload body")
+		return c.View(payload)
 	})
 
 	go app.Start()

--- a/compressor_gzip.go
+++ b/compressor_gzip.go
@@ -11,12 +11,14 @@ import (
 type GzipCompressor struct {
 }
 
-// gzipWriterPool recycles *gzip.Writer across requests. A fresh gzip.Writer
-// carries a 4 KiB bufio.Writer plus a ~256 KiB deflate state at
-// DefaultCompression; allocating it per request dominated the GC profile of
-// compressed apps. The pool is goroutine-safe: each pooled encoder is bound
-// to a single request between Get and Put, and Reset on Get / Put drops any
-// residual reference to the previous ResponseWriter.
+// gzipWriterPool recycles *gzip.Writer across requests. A fresh
+// gzip.Writer at DefaultCompression carries an inner *flate.Writer whose
+// deflate state includes a 64 KiB sliding window plus an up-to-320 KiB
+// fast-encoder history buffer (~384 KiB total). Allocating that state per
+// request dominated the GC profile of compressed apps. The pool is
+// goroutine-safe: each pooled encoder is bound to a single request between
+// Get and Put, and Reset on Get / Put drops any residual reference to the
+// previous ResponseWriter.
 var gzipWriterPool = sync.Pool{
 	New: func() any { return gzip.NewWriter(io.Discard) },
 }
@@ -31,8 +33,11 @@ func (c *GzipCompressor) AcceptEncoding() string {
 // It sets the "Content-Encoding" header to "gzip" and returns the wrapped writer.
 //
 // The *gzip.Writer is acquired from gzipWriterPool and rebound to rw via
-// Reset, so the internal deflate state and bufio buffer are recycled across
-// requests instead of being reallocated on every compressed response.
+// Reset. Reset rebinds the underlying io.Writer and clears the deflate
+// state — gzip.Writer.Reset preserves the inner *flate.Writer pointer, so
+// its 64 KiB sliding window and fast-encoder history buffer are recycled
+// across requests instead of being reallocated on every compressed
+// response.
 func (c *GzipCompressor) New(rw http.ResponseWriter) ResponseWriter {
 	rw.Header().Set("Content-Encoding", "gzip")
 

--- a/compressor_gzip.go
+++ b/compressor_gzip.go
@@ -2,11 +2,23 @@ package xun
 
 import (
 	"compress/gzip"
+	"io"
 	"net/http"
+	"sync"
 )
 
 // GzipCompressor is a struct that provides methods for compressing and decompressing data using the Gzip algorithm.
 type GzipCompressor struct {
+}
+
+// gzipWriterPool recycles *gzip.Writer across requests. A fresh gzip.Writer
+// carries a 4 KiB bufio.Writer plus a ~256 KiB deflate state at
+// DefaultCompression; allocating it per request dominated the GC profile of
+// compressed apps. The pool is goroutine-safe: each pooled encoder is bound
+// to a single request between Get and Put, and Reset on Get / Put drops any
+// residual reference to the previous ResponseWriter.
+var gzipWriterPool = sync.Pool{
+	New: func() any { return gzip.NewWriter(io.Discard) },
 }
 
 // AcceptEncoding returns the encoding type that the GzipCompressor supports.
@@ -17,14 +29,20 @@ func (c *GzipCompressor) AcceptEncoding() string {
 
 // New creates a new gzipResponseWriter that wraps the provided http.ResponseWriter.
 // It sets the "Content-Encoding" header to "gzip" and returns the wrapped writer.
+//
+// The *gzip.Writer is acquired from gzipWriterPool and rebound to rw via
+// Reset, so the internal deflate state and bufio buffer are recycled across
+// requests instead of being reallocated on every compressed response.
 func (c *GzipCompressor) New(rw http.ResponseWriter) ResponseWriter {
 	rw.Header().Set("Content-Encoding", "gzip")
 
+	gz := gzipWriterPool.Get().(*gzip.Writer)
+	gz.Reset(rw)
+
 	return &gzipResponseWriter{
-		w: gzip.NewWriter(rw),
+		w: gz,
 		stdResponseWriter: &stdResponseWriter{
 			ResponseWriter: rw,
 		},
 	}
-
 }

--- a/compressor_gzip_test.go
+++ b/compressor_gzip_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -118,4 +119,88 @@ func TestGzipCompressor(t *testing.T) {
 		})
 	}
 
+}
+
+func TestGzipCompressor_PoolAllocations(t *testing.T) {
+	// Measure allocations over a tight Get/Close cycle. Driving the
+	// measurement through httptest.NewServer + client.Do would let the
+	// HTTP transport's ~60+ allocs/run dwarf the encoder signal; here
+	// we exercise the compressor directly so the pooled-vs-fresh gap
+	// dominates.
+	//
+	// Empirically: pooled is ~13 allocs/run, fresh is ~23 allocs/run.
+	// Threshold 20 catches a regression that reverts to fresh
+	// allocation but tolerates normal noise from
+	// httptest.ResponseRecorder. Note that we cannot assert a
+	// Same-pointer identity between two Get calls: sync.Pool makes
+	// no LIFO guarantee and may evict the encoder between Put and
+	// Get under GC pressure (notably under -race), so an
+	// identity-based test is flaky. The allocation-count signal is
+	// reliable across 1000 iterations because the pool's New func is
+	// only invoked when the per-P cache is empty, not on every Get.
+
+	c := &GzipCompressor{}
+
+	// Warmup: prime the local pool so subsequent Get returns the
+	// pooled encoder rather than invoking New.
+	rw := httptest.NewRecorder()
+	rw.Header().Set("Content-Encoding", "gzip")
+	w := c.New(rw)
+	w.Close()
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		rw := httptest.NewRecorder()
+		rw.Header().Set("Content-Encoding", "gzip")
+		w := c.New(rw)
+		w.Close()
+	})
+
+	require.Less(t, allocs, 20.0,
+		"expected gzip encoder pooling to be active, but allocations per run were %.1f", allocs)
+}
+
+func BenchmarkGzipCompressor(b *testing.B) {
+	fsys := fstest.MapFS{
+		"public/skin.css": {Data: []byte(strings.Repeat("body { color: red; }\n", 64))},
+	}
+
+	m := http.NewServeMux()
+	srv := httptest.NewServer(m)
+	defer srv.Close()
+
+	app := New(WithMux(m), WithFsys(fsys), WithCompressor(&GzipCompressor{}))
+	defer app.Close()
+
+	app.Get("/payload", func(c *Context) error {
+		return c.View("payload body")
+	})
+
+	go app.Start()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/payload", nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	// Warmup: prime the pool and HTTP transport before measuring.
+	for i := 0; i < 10; i++ {
+		resp, err := client.Do(req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resp, err := client.Do(req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
 }

--- a/compressor_gzip_test.go
+++ b/compressor_gzip_test.go
@@ -126,7 +126,7 @@ func TestGzipCompressor_DoubleClose(t *testing.T) {
 	// plus the framework's defer also call Close(); without
 	// idempotency the *gzip.Writer would be Put into gzipWriterPool
 	// twice, letting two concurrent Gets hand the same pointer to two
-	// requests and corrupt shared bufio/deflate state across them.
+	// requests and corrupt shared deflate state across them.
 	c := &GzipCompressor{}
 
 	rw := httptest.NewRecorder()

--- a/compressor_gzip_test.go
+++ b/compressor_gzip_test.go
@@ -127,12 +127,19 @@ func TestGzipCompressor_DoubleClose(t *testing.T) {
 	// idempotency the *gzip.Writer would be Put into gzipWriterPool
 	// twice, letting two concurrent Gets hand the same pointer to two
 	// requests and corrupt shared deflate state across them.
+	//
+	// The same scenario also exercises the post-Close surface: a
+	// wrapper that has been closed (and therefore has rw.w == nil)
+	// must not panic on subsequent Write or Flush calls.
 	c := &GzipCompressor{}
 
 	rw := httptest.NewRecorder()
 	rw.Header().Set("Content-Encoding", "gzip")
 	w := c.New(rw)
 	gw := w.(*gzipResponseWriter)
+
+	_, err := gw.Write([]byte("before-close"))
+	require.NoError(t, err)
 
 	w.Close()
 	require.True(t, gw.closed, "first Close must set the closed flag")
@@ -145,6 +152,22 @@ func TestGzipCompressor_DoubleClose(t *testing.T) {
 	require.NotPanics(t, func() { w.Close() })
 	require.Equal(t, bodyLenAfterFirst, rw.Body.Len(),
 		"second Close must not write additional bytes to the recorder")
+
+	// Post-Close Write must not panic on the nil rw.w and must not
+	// pull a fresh encoder out of the pool into a half-closed
+	// wrapper. It returns (len(p), nil), matching the post-Hijack
+	// no-op convention.
+	require.NotPanics(t, func() {
+		n, err := w.Write([]byte("after-close"))
+		require.NoError(t, err)
+		require.Equal(t, len("after-close"), n)
+	})
+
+	// Post-Close Flush must not panic on the nil rw.w.
+	require.NotPanics(t, func() { w.Flush() })
+
+	require.Equal(t, bodyLenAfterFirst, rw.Body.Len(),
+		"post-Close Write/Flush must not write to the recorder")
 }
 
 func TestGzipCompressor_PoolAllocations(t *testing.T) {

--- a/compressor_gzip_test.go
+++ b/compressor_gzip_test.go
@@ -121,6 +121,32 @@ func TestGzipCompressor(t *testing.T) {
 
 }
 
+func TestGzipCompressor_DoubleClose(t *testing.T) {
+	// Close must be idempotent. A handler that calls c.Response.Close()
+	// plus the framework's defer also call Close(); without
+	// idempotency the *gzip.Writer would be Put into gzipWriterPool
+	// twice, letting two concurrent Gets hand the same pointer to two
+	// requests and corrupt shared bufio/deflate state across them.
+	c := &GzipCompressor{}
+
+	rw := httptest.NewRecorder()
+	rw.Header().Set("Content-Encoding", "gzip")
+	w := c.New(rw)
+	gw := w.(*gzipResponseWriter)
+
+	w.Close()
+	require.True(t, gw.closed, "first Close must set the closed flag")
+	require.Nil(t, gw.w, "first Close must release the encoder pointer")
+
+	bodyLenAfterFirst := rw.Body.Len()
+
+	// Second Close must not panic, must not write to the recorder,
+	// must not re-Put the encoder.
+	require.NotPanics(t, func() { w.Close() })
+	require.Equal(t, bodyLenAfterFirst, rw.Body.Len(),
+		"second Close must not write additional bytes to the recorder")
+}
+
 func TestGzipCompressor_PoolAllocations(t *testing.T) {
 	// Measure allocations over a tight Get/Close cycle. Driving the
 	// measurement through httptest.NewServer + client.Do would let the
@@ -160,19 +186,21 @@ func TestGzipCompressor_PoolAllocations(t *testing.T) {
 }
 
 func BenchmarkGzipCompressor(b *testing.B) {
-	fsys := fstest.MapFS{
-		"public/skin.css": {Data: []byte(strings.Repeat("body { color: red; }\n", 64))},
-	}
+	// 16 KiB of compressible-but-not-trivial payload — typical for a
+	// JSON/HTML response where the encoder's deflate state actually
+	// does work, and where the per-request encoder allocation would
+	// dominate without pooling.
+	payload := strings.Repeat("the quick brown fox jumps over the lazy dog\n", 380)
 
 	m := http.NewServeMux()
 	srv := httptest.NewServer(m)
 	defer srv.Close()
 
-	app := New(WithMux(m), WithFsys(fsys), WithCompressor(&GzipCompressor{}))
+	app := New(WithMux(m), WithCompressor(&GzipCompressor{}))
 	defer app.Close()
 
 	app.Get("/payload", func(c *Context) error {
-		return c.View("payload body")
+		return c.View(payload)
 	})
 
 	go app.Start()

--- a/response_writer_deflate.go
+++ b/response_writer_deflate.go
@@ -26,9 +26,12 @@ type deflateResponseWriter struct {
 // It implements the io.Writer interface.
 //
 // After a successful Hijack, Write is a no-op so the deflate encoder does not
-// emit compressed bytes onto the caller-owned stream.
+// emit compressed bytes onto the caller-owned stream. After Close, Write is
+// also a no-op so a stray write through a wrapper whose encoder has already
+// been returned to the pool does not panic on the nil rw.w nor pull a
+// fresh encoder out of the pool into a half-closed wrapper.
 func (rw *deflateResponseWriter) Write(p []byte) (int, error) {
-	if rw.hijacked {
+	if rw.hijacked || rw.closed {
 		return len(p), nil
 	}
 	n, err := rw.w.Write(p)
@@ -69,9 +72,10 @@ func (rw *deflateResponseWriter) Close() {
 // Flush writes any buffered data to the underlying writer and then flushes
 // the standard response writer. After Hijack transfers ownership of the
 // underlying connection, Flush is a no-op so compressed bytes are not
-// written onto the caller-owned stream.
+// written onto the caller-owned stream. After Close, Flush is also a
+// no-op so a stray flush does not panic on the nil rw.w.
 func (rw *deflateResponseWriter) Flush() {
-	if rw.hijacked {
+	if rw.hijacked || rw.closed {
 		return
 	}
 	rw.w.Flush() // nolint: errcheck

--- a/response_writer_deflate.go
+++ b/response_writer_deflate.go
@@ -12,6 +12,14 @@ import (
 type deflateResponseWriter struct {
 	*stdResponseWriter
 	w *flate.Writer
+	// closed is set after the first Close returns the encoder to the
+	// pool. A second Close is a no-op so the same *flate.Writer is
+	// never Put into deflateWriterPool twice; two concurrent Gets of
+	// the same encoder pointer would corrupt deflate state across
+	// requests. Pre-pool this was harmless because deflate.Writer.Close
+	// is idempotent; pooling turned double-Close into a correctness
+	// hazard.
+	closed bool
 }
 
 // Write writes the data to the underlying deflate writer.
@@ -42,13 +50,20 @@ func (rw *deflateResponseWriter) Write(p []byte) (int, error) {
 // because reusing an encoder whose destination was the caller-owned conn
 // would write pooled-state bytes back into a stream the framework no longer
 // owns. The hijacked guard runs before any pool access.
+//
+// Close is idempotent: a second call after a successful Close is a
+// no-op so the same encoder is never Put twice. Idempotency is
+// required because handlers may explicitly call Close in addition to
+// the framework's defer.
 func (rw *deflateResponseWriter) Close() {
-	if rw.hijacked {
+	if rw.closed || rw.hijacked {
 		return
 	}
+	rw.closed = true
 	rw.w.Close() // nolint: errcheck
 	rw.w.Reset(io.Discard)
 	deflateWriterPool.Put(rw.w)
+	rw.w = nil
 }
 
 // Flush writes any buffered data to the underlying writer and then flushes

--- a/response_writer_deflate.go
+++ b/response_writer_deflate.go
@@ -3,6 +3,7 @@ package xun
 import (
 	"bufio"
 	"compress/flate"
+	"io"
 	"net"
 )
 
@@ -29,13 +30,25 @@ func (rw *deflateResponseWriter) Write(p []byte) (int, error) {
 
 // Close closes the underlying writer, flushing any buffered data to the client.
 // It is important to call this method to ensure all data is properly sent.
-// If Hijack has transferred ownership of the connection to the caller, Close
-// is a no-op so the deflate trailer is not written onto the caller-owned stream.
+//
+// After flushing, the *flate.Writer is returned to deflateWriterPool so the
+// internal deflate state is recycled across requests. Reset(io.Discard)
+// before Put drops the residual reference to the previous ResponseWriter so
+// the pooled encoder does not pin the per-request conn alive.
+//
+// If Hijack has transferred ownership of the connection to the caller,
+// Close is a no-op: the deflate trailer must NOT be written onto the
+// caller-owned stream, and the encoder must NOT be returned to the pool,
+// because reusing an encoder whose destination was the caller-owned conn
+// would write pooled-state bytes back into a stream the framework no longer
+// owns. The hijacked guard runs before any pool access.
 func (rw *deflateResponseWriter) Close() {
 	if rw.hijacked {
 		return
 	}
 	rw.w.Close() // nolint: errcheck
+	rw.w.Reset(io.Discard)
+	deflateWriterPool.Put(rw.w)
 }
 
 // Flush writes any buffered data to the underlying writer and then flushes

--- a/response_writer_gzip.go
+++ b/response_writer_gzip.go
@@ -3,6 +3,7 @@ package xun
 import (
 	"bufio"
 	"compress/gzip"
+	"io"
 	"net"
 )
 
@@ -28,13 +29,26 @@ func (rw *gzipResponseWriter) Write(p []byte) (int, error) {
 }
 
 // Close closes the gzipResponseWriter, ensuring that the underlying writer is also closed.
-// If Hijack has transferred ownership of the connection to the caller, Close
-// is a no-op so the gzip trailer is not written onto the caller-owned stream.
+//
+// After flushing the gzip trailer, the *gzip.Writer is returned to
+// gzipWriterPool so the internal deflate state and bufio buffer are recycled
+// across requests. Reset(io.Discard) before Put drops the residual reference
+// to the previous ResponseWriter so the pooled encoder does not pin the
+// per-request conn alive.
+//
+// If Hijack has transferred ownership of the connection to the caller,
+// Close is a no-op: the gzip trailer must NOT be written onto the
+// caller-owned stream, and the encoder must NOT be returned to the pool,
+// because reusing an encoder whose destination was the caller-owned conn
+// would write pooled-state bytes back into a stream the framework no longer
+// owns. The hijacked guard runs before any pool access.
 func (rw *gzipResponseWriter) Close() {
 	if rw.hijacked {
 		return
 	}
 	rw.w.Close() // nolint: errcheck
+	rw.w.Reset(io.Discard)
+	gzipWriterPool.Put(rw.w)
 }
 
 // Flush writes any buffered data to the underlying writer and then flushes

--- a/response_writer_gzip.go
+++ b/response_writer_gzip.go
@@ -15,8 +15,8 @@ type gzipResponseWriter struct {
 	// closed is set after the first Close returns the encoder to the
 	// pool. A second Close is a no-op so the same *gzip.Writer is
 	// never Put into gzipWriterPool twice; two concurrent Gets of
-	// the same encoder pointer would corrupt shared bufio/deflate
-	// state across requests. Pre-pool this was harmless because
+	// the same encoder pointer would corrupt shared deflate state
+	// across requests. Pre-pool this was harmless because
 	// gzip.Writer.Close is idempotent; pooling turned double-Close
 	// into a correctness hazard.
 	closed bool
@@ -39,9 +39,10 @@ func (rw *gzipResponseWriter) Write(p []byte) (int, error) {
 // Close closes the gzipResponseWriter, ensuring that the underlying writer is also closed.
 //
 // After flushing the gzip trailer, the *gzip.Writer is returned to
-// gzipWriterPool so the internal deflate state and bufio buffer are recycled
-// across requests. Reset(io.Discard) before Put drops the residual reference
-// to the previous ResponseWriter so the pooled encoder does not pin the
+// gzipWriterPool so the inner *flate.Writer's deflate state (64 KiB
+// sliding window + fast-encoder history buffer) is recycled across
+// requests. Reset(io.Discard) before Put drops the residual reference to
+// the previous ResponseWriter so the pooled encoder does not pin the
 // per-request conn alive.
 //
 // If Hijack has transferred ownership of the connection to the caller,

--- a/response_writer_gzip.go
+++ b/response_writer_gzip.go
@@ -12,6 +12,14 @@ import (
 type gzipResponseWriter struct {
 	*stdResponseWriter
 	w *gzip.Writer
+	// closed is set after the first Close returns the encoder to the
+	// pool. A second Close is a no-op so the same *gzip.Writer is
+	// never Put into gzipWriterPool twice; two concurrent Gets of
+	// the same encoder pointer would corrupt shared bufio/deflate
+	// state across requests. Pre-pool this was harmless because
+	// gzip.Writer.Close is idempotent; pooling turned double-Close
+	// into a correctness hazard.
+	closed bool
 }
 
 // Write writes the data to the underlying gzip writer.
@@ -42,13 +50,20 @@ func (rw *gzipResponseWriter) Write(p []byte) (int, error) {
 // because reusing an encoder whose destination was the caller-owned conn
 // would write pooled-state bytes back into a stream the framework no longer
 // owns. The hijacked guard runs before any pool access.
+//
+// Close is idempotent: a second call after a successful Close is a
+// no-op so the same encoder is never Put twice. Idempotency is
+// required because handlers may explicitly call Close in addition to
+// the framework's defer.
 func (rw *gzipResponseWriter) Close() {
-	if rw.hijacked {
+	if rw.closed || rw.hijacked {
 		return
 	}
+	rw.closed = true
 	rw.w.Close() // nolint: errcheck
 	rw.w.Reset(io.Discard)
 	gzipWriterPool.Put(rw.w)
+	rw.w = nil
 }
 
 // Flush writes any buffered data to the underlying writer and then flushes

--- a/response_writer_gzip.go
+++ b/response_writer_gzip.go
@@ -26,9 +26,12 @@ type gzipResponseWriter struct {
 // It implements the io.Writer interface.
 //
 // After a successful Hijack, Write is a no-op so the gzip encoder does not
-// emit compressed bytes onto the caller-owned stream.
+// emit compressed bytes onto the caller-owned stream. After Close, Write is
+// also a no-op so a stray write through a wrapper whose encoder has already
+// been returned to the pool does not panic on the nil rw.w nor pull a
+// fresh encoder out of the pool into a half-closed wrapper.
 func (rw *gzipResponseWriter) Write(p []byte) (int, error) {
-	if rw.hijacked {
+	if rw.hijacked || rw.closed {
 		return len(p), nil
 	}
 	n, err := rw.w.Write(p)
@@ -70,9 +73,10 @@ func (rw *gzipResponseWriter) Close() {
 // Flush writes any buffered data to the underlying writer and then flushes
 // the standard response writer. After Hijack transfers ownership of the
 // underlying connection, Flush is a no-op so compressed bytes are not
-// written onto the caller-owned stream.
+// written onto the caller-owned stream. After Close, Flush is also a
+// no-op so a stray flush does not panic on the nil rw.w.
 func (rw *gzipResponseWriter) Flush() {
-	if rw.hijacked {
+	if rw.hijacked || rw.closed {
 		return
 	}
 	rw.w.Flush() // nolint: errcheck


### PR DESCRIPTION
## Summary by NightMe
Package-level `sync.Pool` recycles the `*gzip.Writer` / `*flate.Writer` (and their ~384 KiB deflate state at `DefaultCompression`) that used to be freshly allocated per compressed response. Follow-up commits harden the pooled wrapper so a handler that calls `c.Response.Close()` alongside the framework's defer can't double-`Put` the encoder or panic on post-`Close` writes.

Enhancements:
- compressor_gzip.go: `GzipCompressor.New` now `Get`s from `gzipWriterPool` and `Reset`s the encoder, so the inner `flate.Writer`'s 64 KiB window and up-to-320 KiB fast-encoder history are reused instead of reallocated per request.
- compressor_deflate.go: `DeflateCompressor.New` mirrors the same pattern against `deflateWriterPool`, so the ~384 KiB deflate state is recycled across requests.
- response_writer_gzip.go: `Close` now `Reset(io.Discard)`s the encoder and `Put`s it back into the pool to drop the residual reference to the previous ResponseWriter, and skips the pool entirely when `Hijack` has transferred ownership of the conn (so pooled bytes never land in a caller-owned stream).
- response_writer_deflate.go: same pooled-`Close` treatment for the deflate encoder.

Documentation:
- compressor_gzip.go, compressor_deflate.go, response_writer_gzip.go, compressor_gzip_test.go: pool comments corrected to name the actual reused buffers (`compress/gzip.Writer` lost its `bufio.Writer` in Go 1.21; `flate.Writer` never reallocates its window/history inside `reset()`), so the pool is documented as saving ~384 KiB/request rather than the outdated 4+256 KiB estimate.

Bug Fixes:
- response_writer_gzip.go, response_writer_deflate.go: `Close` is now idempotent via a `closed` flag so a handler's explicit `c.Response.Close()` plus the framework's defer can't `Put` the same encoder into the pool twice (two concurrent `Get`s of one pointer would corrupt deflate state across requests; hazard was masked pre-pool because `gzip.Writer.Close` / `flate.Writer.Close` were idempotent).
- response_writer_gzip.go, response_writer_deflate.go: `Write` and `Flush` now short-circuit on `rw.closed` alongside `rw.hijacked`, so a stray write or flush on a wrapper whose encoder has already been returned to the pool returns `(len(p), nil)` / no-op instead of nil-dereferencing `rw.w`.
- compressor_gzip_test.go, compressor_deflate_test.go: benchmarks drop the unused `fstest.MMapFS` and replace the 12-byte payload with a 16 KiB string so the encoder's deflate work dominates the measurement instead of the HTTP transport's bookkeeping.

Tests:
- compressor_gzip_test.go, compressor_deflate_test.go: `TestGzipCompressor_DoubleClose` / `TestDeflateCompressor_DoubleClose` pin idempotent `Close`, `rw.w == nil` after Close, and panic-free post-`Close` `Write` / `Flush`.
- compressor_gzip_test.go, compressor_deflate_test.go: `TestGzipCompressor_PoolAllocations` / `TestDeflateCompressor_PoolAllocations` assert `AllocsPerRun` over a tight Get/Close cycle stays below a threshold that excludes a fresh per-request encoder allocation (~13 pooled vs ~23 fresh).
- compressor_gzip_test.go, compressor_deflate_test.go: `BenchmarkGzipCompressor` / `BenchmarkDeflateCompressor` measure steady-state ns/op and B/op for a full HTTP round-trip.

Risk: medium — every compressed response now goes through the pooled path; the hijacked guard (skip pool when the conn was hijacked), idempotent `Close`, and post-`Close` `Write`/`Flush` guards cover the three ways the new `closed` + `rw.w = nil` state could otherwise corrupt shared state or panic.

Closes #130

## Summary by Sourcery

Pool gzip and deflate encoders across requests to reduce compressed-response memory overhead while keeping close and hijack handling safe.

Bug Fixes:
- Make gzip and deflate response writer closure safe and idempotent, including harmless post-close writes and flushes.

Enhancements:
- Reuse gzip and deflate writers across compressed responses to reduce allocation and garbage-collection overhead.
- Safely return completed encoders to pools while preserving hijacked connection ownership semantics.

Documentation:
- Update compressor documentation to accurately describe the memory reused by pooled encoders.

Tests:
- Add coverage for double-close behavior, post-close operations, pooling allocations, and compressed response benchmarks.