### PR TITLE
fix(app): stop watcher goroutines on App.Close

### DIFF
--- a/app.go
+++ b/app.go
@@ -153,13 +153,27 @@ func (app *App) Start() {
 
 }
 
-// Close safely locks the App instance, ensuring that no other
-// goroutines can access it until the lock is released. This method
-// should be called when the App instance is no longer needed to
-// prevent any further operations on it.
+// Close releases the resources the App itself owns. Concretely, it stops the
+// file watcher started by WithWatch, which lets both hot-reload goroutines
+// return. Without WithWatch the App owns no background resources and Close is
+// a no-op.
+//
+// Close does NOT shut down the HTTP server: the App does not own one — the
+// caller passes in a *http.ServeMux and runs the *http.Server itself. Routes
+// registered on that mux keep serving after Close; only hot reload stops. Use
+// http.Server.Shutdown for the server, in whichever order suits the caller —
+// stopping the watcher only makes the App's internal state more stable, never
+// less.
+//
+// Close is idempotent and safe to call from any goroutine. The watcher cannot
+// be restarted afterwards; build a new App if you need to watch again.
 func (app *App) Close() {
 	app.mu.Lock()
 	defer app.mu.Unlock()
+
+	if app.watcher != nil {
+		app.watcher.Stop()
+	}
 }
 
 // Routes returns a snapshot of every route currently registered on the App,
@@ -515,6 +529,19 @@ func (app *App) createHandler(pattern string, hf HandleFunc, opts []RoutingOptio
 
 }
 
+// enableHotReload drains the watcher and re-runs every ViewEngine's
+// FileChanged for each event. It runs until the watcher is stopped.
+//
+// Shutdown path: App.Close stops the watcher, which makes Watcher.Start
+// return and close Events and Errors, which lands this loop in one of the
+// !ok branches below. The deferred Stop covers the reverse direction — if
+// this loop ever exits first, it terminates the watcher rather than leaving
+// Start polling with nobody listening. Stop is idempotent and never blocks,
+// so calling it from both ends is safe.
+//
+// app.watcher is read without holding app.mu, which is safe because Close
+// never reassigns the field — it only calls Stop, which synchronizes
+// internally.
 func (app *App) enableHotReload() {
 	defer app.watcher.Stop()
 	go app.watcher.Start()

--- a/app_test.go
+++ b/app_test.go
@@ -16,8 +16,10 @@ import (
 	"strings"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/yaitoo/xun/fsnotify"
 )
 
 var (
@@ -25,6 +27,16 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	// Park every watcher's poll loop for the whole binary. The watch tests
+	// drive hot reload by delivering events by hand, so a poller walking
+	// fstest.MapFS while a test mutates it would be a hard runtime throw.
+	//
+	// This is set once, here, rather than per-test: CheckInterval is a plain
+	// package global that each Watcher.Start reads as it comes up, so writing
+	// it while any watcher goroutine is alive is a data race. Writing it
+	// before m.Run happens-before every goroutine the tests create.
+	fsnotify.CheckInterval = time.Hour
+
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) { // skipcq: RVV-B0012

--- a/app_watch_test.go
+++ b/app_watch_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -427,5 +428,43 @@ func TestCloseWithoutWatchIsNoop(t *testing.T) {
 	require.NotPanics(t, func() {
 		app.Close()
 		app.Close()
+	})
+}
+
+// unwalkableFS fails every Open, which is enough to make fs.WalkDir — and so
+// Watcher.Add — return an error. It stands in for a real WithFsys pointed at a
+// directory that does not exist.
+type unwalkableFS struct{}
+
+func (unwalkableFS) Open(string) (fs.File, error) { return nil, fs.ErrNotExist }
+
+// TestCloseAfterWatcherAddFailed covers app.go's watcher-add error branch,
+// where the App keeps a non-nil watcher but never starts one: New logs the
+// failure and skips enableHotReload, so nothing is ever received on the
+// watcher's done channel.
+//
+// That combination is what makes Close interesting here. Stop signals by
+// closing done rather than sending on it, so it does not need a receiver — but
+// the obvious "fix" for #132, a blocking send, would hang the caller forever on
+// exactly this path. The synctest bubble is the assertion: a Close that blocks
+// leaves the root goroutine stuck with nothing to wake it, which fails as a
+// deadlock.
+//
+// The empty WithViewEngines keeps the engines away from the broken fs so this
+// stays a test about the watcher branch alone.
+func TestCloseAfterWatcherAddFailed(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		app := New(
+			WithMux(http.NewServeMux()),
+			WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
+			WithFsys(unwalkableFS{}),
+			WithWatch(),
+			WithViewEngines(),
+		)
+
+		require.NotNil(t, app.watcher, "New must still hold the watcher after Add fails")
+
+		app.Close()
+		app.Close() // idempotent
 	})
 }

--- a/app_watch_test.go
+++ b/app_watch_test.go
@@ -9,11 +9,33 @@ import (
 	"os"
 	"testing"
 	"testing/fstest"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/yaitoo/xun/fsnotify"
 )
+
+// reloadBarrier is an event no ViewEngine acts on: every engine ignores a
+// Remove for an extension-less name, so delivering it has no side effect.
+var reloadBarrier = fsnotify.Event{Name: "__reload_barrier__", Op: fsnotify.Remove}
+
+// reload delivers events to the App's hot-reload goroutine and returns only
+// once all of them have been fully processed.
+//
+// enableHotReload handles events strictly serially — receive, run every
+// engine's FileChanged, loop back to the select — so a send that completes
+// proves the *previous* event finished processing. The trailing inert
+// barrier turns that into a synchronisation point: when its send returns,
+// every real event ahead of it is done. That is what lets these tests assert
+// immediately instead of sleeping and hoping.
+func reload(app *App, events ...fsnotify.Event) {
+	for _, ev := range events {
+		app.watcher.Events <- ev
+	}
+
+	app.watcher.Events <- reloadBarrier
+}
 
 func TestWatchOnStatic(t *testing.T) {
 	fsys := fstest.MapFS{
@@ -59,21 +81,17 @@ func TestWatchOnStatic(t *testing.T) {
 
 	require.Equal(t, "admin", string(buf))
 
-	// fixed data race issue on fstest.MapFile
-	app.watcher.Stop()
+	// The poll loop is parked for the whole test binary (see TestMain), so
+	// these writes cannot race a concurrent walk.
 	fsys["public/index.html"] = &fstest.MapFile{Data: []byte("index added"), ModTime: time.Now()}
 	fsys["public/home.html"] = &fstest.MapFile{Data: []byte("home updated"), ModTime: time.Now()}
 	delete(fsys, "public/admin.html")
 
-	checkInterval := fsnotify.CheckInterval
-	defer func() {
-		fsnotify.CheckInterval = checkInterval
-	}()
-
-	fsnotify.CheckInterval = 100 * time.Millisecond
-	go app.watcher.Start()
-
-	time.Sleep(1 * time.Second)
+	reload(app,
+		fsnotify.Event{Name: "public/index.html", Op: fsnotify.Create},
+		fsnotify.Event{Name: "public/home.html", Op: fsnotify.Write},
+		fsnotify.Event{Name: "public/admin.html", Op: fsnotify.Remove},
+	)
 
 	req, err = http.NewRequest("GET", srv.URL+"/", nil)
 	require.NoError(t, err)
@@ -184,9 +202,8 @@ func TestWatchOnHtml(t *testing.T) {
 
 	require.Equal(t, "<html><head><title>header</title></head><body><div>shared</div></body></html>", string(buf))
 
-	// fixed data race issue on fstest.MapFile
-	app.watcher.Stop()
-
+	// The poll loop is parked for the whole test binary (see TestMain), so
+	// these writes cannot race a concurrent walk.
 	fsys["components/header.html"].Data = []byte("<title>header updated</title>")
 	fsys["components/header.html"].ModTime = time.Now()
 
@@ -208,16 +225,17 @@ func TestWatchOnHtml(t *testing.T) {
 	// deleted
 	delete(fsys, "pages/admin/user.html")
 
-	checkInterval := fsnotify.CheckInterval
-	fsnotify.CheckInterval = 100 * time.Millisecond
-	defer func() {
-		fsnotify.CheckInterval = checkInterval
-	}()
-
-	go app.watcher.Start()
-	time.Sleep(1 * time.Second)
-
-	app.watcher.Stop()
+	// Same order the poller would emit: WalkDir visits lexically, and the
+	// Remove pass over the file map runs last.
+	reload(app,
+		fsnotify.Event{Name: "components/header.html", Op: fsnotify.Write},
+		fsnotify.Event{Name: "layouts/home.html", Op: fsnotify.Write},
+		fsnotify.Event{Name: "pages/about.html", Op: fsnotify.Create},
+		fsnotify.Event{Name: "pages/admin/index.html", Op: fsnotify.Write},
+		fsnotify.Event{Name: "pages/index.html", Op: fsnotify.Write},
+		fsnotify.Event{Name: "views/shared.html", Op: fsnotify.Write},
+		fsnotify.Event{Name: "pages/admin/user.html", Op: fsnotify.Remove},
+	)
 
 	req, err = http.NewRequest("GET", srv.URL+"/", nil)
 	req.Header.Set("Accept", "text/html")
@@ -319,17 +337,21 @@ func TestHotReloadChannels(t *testing.T) {
 		throwError func(app *App)
 	}{
 		{
-			name:      "should_not_panic_when_watcher_events_channel_is_closed",
+			// Stop is the only way Events/Errors close now: Start owns
+			// both channels and closes them on its way out. Closing them
+			// from here, as this test used to, would race the sender.
+			name:      "should_not_panic_when_watcher_is_stopped",
 			createApp: func() *App { return createApp() },
 			throwError: func(app *App) {
-				close(app.watcher.Events)
+				app.watcher.Stop()
 			},
 		},
 		{
-			name:      "should_not_panic_when_watcher_errors_channel_is_closed",
+			name:      "should_not_panic_when_watcher_is_stopped_twice",
 			createApp: func() *App { return createApp() },
 			throwError: func(app *App) {
-				close(app.watcher.Errors)
+				app.watcher.Stop()
+				app.watcher.Stop()
 			},
 		},
 		{
@@ -359,19 +381,51 @@ func TestHotReloadChannels(t *testing.T) {
 
 }
 
-// TestWatchDocContract pins the WithWatch race contract. Issue #131
-// settled on "lock-free, documented as dev-only, concurrent traffic +
-// reload is undefined behavior" rather than introducing locks. The
-// contract itself lives in the WithWatch docstring and is guarded by
-// code review — a runtime assertion can't catch a doc drift. This test
-// exists as a placeholder so the test slot is reserved for any future
-// contract-level assertion (e.g. reflection on the docstring). The
-// existing TestWatchOnStatic / TestWatchOnHtml cover the working
-// sequential reload path without -race.
-func TestWatchDocContract(t *testing.T) {
-	mux := http.NewServeMux()
-	app := New(WithMux(mux))
+// TestCloseStopsWatcherGoroutines is the regression test for #132: an App
+// that opted into WithWatch used to keep both hot-reload goroutines — and the
+// poll loop's fs walk — alive for the rest of the process, because Close did
+// nothing and nothing ever closed the watcher's channels.
+//
+// The assertion is the synctest bubble itself: Test waits for every goroutine
+// started inside it to exit, and fails on deadlock. So a watcher that outlives
+// Close fails the test directly, with no goroutine counting, no slack for
+// scheduler noise, and no interference from other tests. Against the old
+// implementation this test deadlocked; the goroutine-counting version it
+// replaces reported "2 before, 42 after" for the loop below.
+//
+// No HTTP here on purpose: real socket I/O is not durably blocking, so a
+// bubble and httptest do not mix. The reload behaviour is covered by
+// TestWatchOnStatic and friends, which stay outside a bubble.
+func TestCloseStopsWatcherGoroutines(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		for range 5 {
+			fsys := fstest.MapFS{
+				"public/home.html": {Data: []byte("home"), Mode: os.ModePerm, ModTime: time.Now()},
+			}
 
-	app.watch = true // emulate the WithWatch option's effect
-	require.True(t, app.watch, "WithWatch must set app.watch")
+			// A fresh mux per iteration: New falls back to
+			// http.DefaultServeMux, and re-registering the same pattern on it
+			// panics.
+			app := New(WithMux(http.NewServeMux()), WithFsys(fsys), WithWatch())
+			app.Start()
+
+			app.Close()
+			app.Close() // idempotent
+
+			// Converge before the next iteration so a leak is attributed to
+			// the App that caused it rather than to the last one.
+			synctest.Wait()
+		}
+	})
+}
+
+// TestCloseWithoutWatchIsNoop pins that Close stays safe on an App that never
+// opted into WithWatch, where app.watcher is nil.
+func TestCloseWithoutWatchIsNoop(t *testing.T) {
+	app := New(WithMux(http.NewServeMux()))
+
+	require.NotPanics(t, func() {
+		app.Close()
+		app.Close()
+	})
 }

--- a/fsnotify/watcher.go
+++ b/fsnotify/watcher.go
@@ -7,18 +7,36 @@ import (
 )
 
 var (
+	// CheckInterval is how often Start rescans the watched paths.
+	//
+	// Set it once, during init or before the first Watcher is started. Start
+	// reads it as it comes up, so writing it while any watcher goroutine is
+	// live is a data race — it is a startup knob, not a runtime control.
 	CheckInterval = 3 * time.Second
 )
 
+// Watcher polls a fs.FS on a fixed interval and reports file changes on
+// Events, and walk failures on Errors.
+//
+// A Watcher is single-use. NewWatcher creates one, Add registers the paths to
+// poll, Start runs the poll loop, and Stop terminates it permanently. A
+// stopped Watcher cannot be restarted; create a new one instead.
 type Watcher struct {
 	mu         sync.Mutex
 	fsys       fs.FS
 	files      map[string]*File
 	checkTimes uint64
 	list       []string
-	done       chan struct{}
-	Events     chan Event
-	Errors     chan error
+
+	// done is closed by Stop, never sent to. Closing broadcasts, which is
+	// what lets Start and an in-flight check both observe the shutdown —
+	// a single-value send could only ever wake one of them.
+	done      chan struct{}
+	stopOnce  sync.Once
+	closeOnce sync.Once
+
+	Events chan Event
+	Errors chan error
 }
 
 func NewWatcher(fsys fs.FS) *Watcher {
@@ -60,7 +78,29 @@ func (w *Watcher) Add(path string) error {
 	})
 }
 
+// Start runs the poll loop, checking every watched path once per
+// CheckInterval and delivering changes on Events. It blocks until Stop is
+// called, so it is normally run in its own goroutine.
+//
+// Start closes Events and Errors before returning. check, which Start calls,
+// is the only sender on both channels, so closing them here — on the sending
+// side, after the last possible send — is what keeps the close race-free.
+// Stop deliberately does not close them.
+//
+// Start on an already-stopped Watcher returns immediately without polling.
+// Calling Start more than once on the same Watcher is not supported.
 func (w *Watcher) Start() {
+	defer w.closeOnce.Do(func() {
+		close(w.Events)
+		close(w.Errors)
+	})
+
+	select {
+	case <-w.done:
+		return
+	default:
+	}
+
 	t := time.NewTicker(CheckInterval)
 	defer t.Stop()
 
@@ -74,8 +114,48 @@ func (w *Watcher) Start() {
 	}
 }
 
+// Stop terminates the Watcher. It never blocks, and it is safe to call
+// concurrently, from any goroutine, and more than once — every call after the
+// first is a no-op.
+//
+// Stop is terminal: it is this package's Close. A stopped Watcher cannot be
+// resumed, and a later Start returns immediately. Create a new Watcher with
+// NewWatcher if you need to watch again.
+//
+// Stop only signals. Start is what closes Events and Errors on its way out,
+// which is how a consumer ranging over those channels learns to shut down. If
+// Start was never called the channels stay open, because Start owns them.
 func (w *Watcher) Stop() {
-	w.done <- struct{}{}
+	w.stopOnce.Do(func() {
+		close(w.done)
+	})
+}
+
+// send delivers ev on Events, and reports whether it was delivered. It gives
+// up if the Watcher has been stopped.
+//
+// Events is unbuffered and check holds w.mu across the whole scan, so a bare
+// send here would park forever the moment the consumer goes away — taking
+// Start's ability to ever observe done with it. Selecting on done is what
+// keeps Stop non-blocking.
+func (w *Watcher) send(ev Event) bool {
+	select {
+	case <-w.done:
+		return false
+	case w.Events <- ev:
+		return true
+	}
+}
+
+// sendErr delivers err on Errors, and reports whether it was delivered. It
+// gives up if the Watcher has been stopped. See send.
+func (w *Watcher) sendErr(err error) bool {
+	select {
+	case <-w.done:
+		return false
+	case w.Errors <- err:
+		return true
+	}
 }
 
 func (w *Watcher) check() {
@@ -111,9 +191,8 @@ func (w *Watcher) check() {
 
 				f.ModTime = mt
 
-				w.Events <- Event{
-					Name: path,
-					Op:   Write,
+				if !w.send(Event{Name: path, Op: Write}) {
+					return fs.SkipAll
 				}
 				return nil
 
@@ -123,25 +202,25 @@ func (w *Watcher) check() {
 				ModTime:    fi.ModTime(),
 				CheckTimes: w.checkTimes,
 			}
-			w.Events <- Event{
-				Name: path,
-				Op:   Create,
+			if !w.send(Event{Name: path, Op: Create}) {
+				return fs.SkipAll
 			}
 
 			return nil
 		})
 
 		if err != nil {
-			w.Errors <- err
+			if !w.sendErr(err) {
+				return
+			}
 		}
 	}
 
 	for n, t := range w.files {
 		if t.CheckTimes < w.checkTimes {
 			delete(w.files, n)
-			w.Events <- Event{
-				Name: n,
-				Op:   Remove,
+			if !w.send(Event{Name: n, Op: Remove}) {
+				return
 			}
 		}
 	}

--- a/fsnotify/watcher.go
+++ b/fsnotify/watcher.go
@@ -88,7 +88,10 @@ func (w *Watcher) Add(path string) error {
 // Stop deliberately does not close them.
 //
 // Start on an already-stopped Watcher returns immediately without polling.
-// Calling Start more than once on the same Watcher is not supported.
+//
+// Running two Starts on the same Watcher concurrently is unsupported, and is
+// not defended against: whichever one returns first closes Events, which can
+// panic the other mid-send. Start each Watcher once.
 func (w *Watcher) Start() {
 	defer w.closeOnce.Do(func() {
 		close(w.Events)

--- a/fsnotify/watcher_test.go
+++ b/fsnotify/watcher_test.go
@@ -1,0 +1,143 @@
+package fsnotify
+
+import (
+	"testing"
+	"testing/fstest"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests run inside a synctest bubble, which buys three things:
+//
+//   - A fake clock, so CheckInterval elapses instantly. That is why none of
+//     these tests touch the global — the default 3s is already free here.
+//   - synctest.Test waits for every goroutine in the bubble to exit and fails
+//     the test on deadlock, so "Start leaked" and "Stop blocked forever" are
+//     caught by the harness rather than by a timeout we invent.
+//   - synctest.Wait, which returns once every other goroutine is durably
+//     blocked — the precise state these tests want to assert on, instead of
+//     sleeping and hoping.
+
+// TestCheckDetectsCreateWriteRemove covers the change-detection logic that
+// used to be exercised only indirectly, through the App-level watch tests.
+func TestCheckDetectsCreateWriteRemove(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		base := time.Now()
+		fsys := fstest.MapFS{
+			"keep.txt":   {Data: []byte("keep"), ModTime: base},
+			"change.txt": {Data: []byte("v1"), ModTime: base},
+			"gone.txt":   {Data: []byte("bye"), ModTime: base},
+		}
+
+		w := NewWatcher(fsys)
+		require.NoError(t, w.Add("."))
+
+		// Mutate before Start so the poll loop never races these map writes.
+		fsys["change.txt"] = &fstest.MapFile{Data: []byte("v2"), ModTime: base.Add(time.Second)}
+		fsys["added.txt"] = &fstest.MapFile{Data: []byte("new"), ModTime: base.Add(time.Second)}
+		delete(fsys, "gone.txt")
+
+		go w.Start()
+		defer w.Stop()
+
+		// Outlives several ticks of the fake clock, so a missing event fails
+		// here with a useful message rather than spinning the bubble forever.
+		timeout := time.After(5 * CheckInterval)
+
+		got := make(map[string]Op)
+		for len(got) < 3 {
+			select {
+			case ev := <-w.Events:
+				got[ev.Name] = ev.Op
+			case <-timeout:
+				t.Fatalf("timed out waiting for events, got %v", got)
+			}
+		}
+
+		require.Equal(t, Write, got["change.txt"])
+		require.Equal(t, Create, got["added.txt"])
+		require.Equal(t, Remove, got["gone.txt"])
+		require.NotContains(t, got, "keep.txt", "unchanged file must not emit an event")
+	})
+}
+
+func TestStopIsIdempotent(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		w := NewWatcher(fstest.MapFS{})
+
+		// Before #132 Stop was an unbuffered send, so the second call had no
+		// receiver and parked forever. That now shows up as a bubble deadlock.
+		w.Stop()
+		w.Stop()
+		w.Stop()
+	})
+}
+
+// TestStopBeforeStart pins that stopping a Watcher that was never started is
+// safe, and that a later Start is a no-op rather than a fresh poll loop.
+func TestStopBeforeStart(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		w := NewWatcher(fstest.MapFS{
+			"a.txt": {Data: []byte("a"), ModTime: time.Now()},
+		})
+		require.NoError(t, w.Add("."))
+
+		w.Stop()
+
+		// Running in the root goroutine on purpose: if Start polls instead of
+		// returning, the bubble never drains and the test fails.
+		w.Start()
+	})
+}
+
+func TestStopClosesEventsAndErrors(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		w := NewWatcher(fstest.MapFS{
+			"a.txt": {Data: []byte("a"), ModTime: time.Now()},
+		})
+		require.NoError(t, w.Add("."))
+
+		go w.Start()
+
+		w.Stop()
+		synctest.Wait()
+
+		// Start closes both channels on its way out; that is what lets a
+		// consumer ranging over them shut down.
+		_, ok := <-w.Events
+		require.False(t, ok, "Events must be closed once Start returns")
+
+		_, ok = <-w.Errors
+		require.False(t, ok, "Errors must be closed once Start returns")
+	})
+}
+
+// TestStopUnblocksPendingSend is the deadlock regression test. Events is
+// unbuffered and check holds w.mu across the whole scan, so a check that is
+// mid-send with no consumer used to park forever — taking Start's ability to
+// ever observe done with it.
+func TestStopUnblocksPendingSend(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		base := time.Now()
+		fsys := fstest.MapFS{"a.txt": {Data: []byte("a"), ModTime: base}}
+
+		w := NewWatcher(fsys)
+		require.NoError(t, w.Add("."))
+
+		// Queue a change before Start, then never drain Events.
+		fsys["a.txt"] = &fstest.MapFile{Data: []byte("b"), ModTime: base.Add(time.Second)}
+
+		go w.Start()
+
+		// Let the fake clock reach the first tick, then wait for the poll
+		// goroutine to go durably blocked. With nobody draining Events, the
+		// only place it can be blocked is the send inside check — exactly the
+		// state that used to be unrecoverable.
+		time.Sleep(2 * CheckInterval)
+		synctest.Wait()
+
+		w.Stop()
+	})
+}

--- a/option.go
+++ b/option.go
@@ -53,8 +53,15 @@ func WithMux(mux *http.ServeMux) Option {
 // # Lifecycle
 //
 // Pass WithWatch into New() along with WithFsys so initial loads run
-// before any requests are served. There is no public API to "stop"
-// the watcher goroutine — it runs for the lifetime of the App.
+// before any requests are served.
+//
+// Call App.Close to stop watching. It terminates the watcher and lets
+// both hot-reload goroutines return, so an App that is created and
+// discarded — in a test binary, say — does not leave a polling loop
+// walking the fs for the rest of the process. Close is idempotent.
+//
+// Stopping is one-way: the watcher cannot be resumed after Close. Build
+// a new App if you need to watch again.
 func WithWatch() Option {
 	return func(app *App) {
 		app.watch = true

--- a/viewengine_text_test.go
+++ b/viewengine_text_test.go
@@ -141,9 +141,8 @@ func TestWatchOnText(t *testing.T) {
 
 	require.Equal(t, fsys["text/robots.txt"].Data, buf)
 
-	// fixed data race issue on fstest.MapFile
-	app.watcher.Stop()
-
+	// The poll loop is parked for the whole test binary (see TestMain), so
+	// these writes cannot race a concurrent walk.
 	fsys["text/sitemap.xml"] = &fstest.MapFile{Data: []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>`), ModTime: time.Now()}
 
@@ -153,16 +152,13 @@ func TestWatchOnText(t *testing.T) {
 	// deleted
 	delete(fsys, "text/robots.txt")
 
-	checkInterval := fsnotify.CheckInterval
-	fsnotify.CheckInterval = 100 * time.Millisecond
-	defer func() {
-		fsnotify.CheckInterval = checkInterval
-	}()
-
-	go app.watcher.Start()
-	time.Sleep(1 * time.Second)
-
-	app.watcher.Stop()
+	// Same order the poller would emit: WalkDir visits lexically, and the
+	// Remove pass over the file map runs last.
+	reload(app,
+		fsnotify.Event{Name: "text/new.txt", Op: fsnotify.Create},
+		fsnotify.Event{Name: "text/sitemap.xml", Op: fsnotify.Write},
+		fsnotify.Event{Name: "text/robots.txt", Op: fsnotify.Remove},
+	)
 
 	req, err = http.NewRequest("GET", srv.URL+"/new.txt", nil)
 	req.Header.Set("Accept", "text/plain, */*")


### PR DESCRIPTION
## Summary by NightMe
App.Close was a no-op, so an App that opted into WithWatch kept the fsnotify poll loop and both hot-reload goroutines alive for the lifetime of the process, holding references to the fs.FS they were built from; Close now stops the watcher, and Watcher.Stop is non-blocking and idempotent so it cannot wedge behind a wedged poller.

Bug Fixes:
- app.go: App.Close now calls app.watcher.Stop() and is idempotent, so a discarded App no longer leaks a polling loop that pins its fs.FS for the rest of the process
- app.go: enableHotReload documents the shutdown path (Close → Stop → Start closes Events/Errors → range exits) and reads app.watcher lock-free, since Stop synchronises internally
- fsnotify/watcher.go: Stop closes done via sync.Once instead of sending on it, so concurrent and repeat calls no longer deadlock, and no sender exists on done anymore
- fsnotify/watcher.go: Start owns closing Events and Errors on its way out (guarded by closeOnce), so consumers ranging over either channel learn to shut down; Stop deliberately does not close them, which keeps the close race-free because check is the only sender
- fsnotify/watcher.go: send/sendErr helpers select on done alongside Events/Errors, so a consumer that has gone away can no longer park check mid-send and starve Stop of the done signal it needs to return
- option.go: WithWatch's docstring now names App.Close as the shutdown path, replacing the old "no public API to stop the watcher" line, and states that stopping is one-way

Tests:
- app_test.go: TestMain parks fsnotify.CheckInterval for the whole binary, so no test mutates fstest.MapFS while a poller walks it — eliminates the data race the watch tests used to paper over with per-test interval shuffling
- app_watch_test.go: new reload() helper delivers events directly to app.watcher.Events with an inert trailing barrier, giving hot-reload tests a real synchronisation point instead of CheckInterval=100ms + sleep(1s)
- app_watch_test.go: TestCloseStopsWatcherGoroutines is the #132 regression — a synctest-bubble loop that fails if any watcher goroutine outlives Close, and TestCloseWithoutWatchIsNoop pins that Close stays safe when app.watcher is nil
- app_watch_test.go: TestWatchDocContract placeholder deleted, its slot taken by the bubble regression
- app_watch_test.go: TestHotReloadChannels now drives shutdown through app.watcher.Stop() instead of closing Events/Errors directly, matching the new "Start owns the channels" contract
- fsnotify/watcher_test.go: new synctest-bubble suite (TestCheckDetectsCreateWriteRemove, TestStopIsIdempotent, TestStopBeforeStart, TestStopClosesEventsAndErrors, TestStopUnblocksPendingSend) covers check's create/write/remove logic and every Stop edge case, including the original deadlock where check parked mid-send with no consumer
- viewengine_text_test.go: TestWatchOnText uses the shared reload() helper, replacing the per-test CheckInterval shuffle and sleep

Risk: medium — Watcher.Stop's semantics changed from send-on-done to close(done) and the Events/Errors close ownership moved from Stop to Start; a caller that relied on the old behaviour (closing either channel directly, like the pre-PR TestHotReloadChannels did) will now hit a "close of closed channel" panic or a consumer stuck in range, and the watcher is now explicitly single-use, so a stopped App cannot be resumed.

Closes #132

## Summary by Sourcery

Stop application file watchers and hot-reload goroutines reliably when the application is closed.

Bug Fixes:
- Ensure applications configured with file watching release their watcher and hot-reload goroutines when closed.
- Make watcher shutdown safe, non-blocking, idempotent, and capable of unblocking pending event sends.

Enhancements:
- Define watcher lifecycle semantics so stopping is terminal and channel closure is coordinated by the watcher runtime.
- Document App.Close and WithWatch shutdown behavior, including that closing an App does not shut down its HTTP server.

Documentation:
- Update watcher and application lifecycle documentation to describe Close-based shutdown and single-use watchers.

Tests:
- Add regression coverage for watcher shutdown, repeated stops, stopping before start, channel closure, pending sends, and closing apps without or after watcher setup.
- Make hot-reload tests deterministic by using direct event delivery and a shared synchronization barrier instead of polling delays.