### PR TITLE
perf(contentrenderer): parse AST once and reuse pooled render buffer

### DIFF
--- a/content.go
+++ b/content.go
@@ -208,17 +208,3 @@ func buildContentView(mdPath string, fi fs.FileInfo, contentDir, title, descript
 		Body:        body,
 	}
 }
-
-// extractContentView combines filesystem info and Markdown semantics into a
-// ContentView. The Body field is left zero; the caller fills it after rendering.
-//
-// Title and Description are derived from the Markdown AST. If the document
-// has no # H1, Title is left empty (callers should guard with {{if .Title}}).
-//
-// For the loadContentFile path, prefer Process directly to avoid paying
-// for the AST parse twice (once here, once in the subsequent render).
-func extractContentView(mdPath string, content []byte, fi fs.FileInfo, contentDir string, r *contentRenderer) ContentView {
-	doc := r.parser.Parse(text.NewReader(content))
-	title, description := r.extractFromAST(doc, content)
-	return buildContentView(mdPath, fi, contentDir, title, description, template.HTML(""))
-}

--- a/content.go
+++ b/content.go
@@ -1,7 +1,6 @@
 package xun
 
 import (
-	"bytes"
 	"html/template"
 	"io/fs"
 	"strings"
@@ -52,8 +51,8 @@ func newContentRenderer() *contentRenderer {
 	}
 }
 
-// Extract walks the parsed AST once and returns the first H1 title and the
-// first blockquote-or-paragraph description.
+// extractFromAST walks an already-parsed AST and returns the first H1 title
+// and the first blockquote-or-paragraph description.
 //
 // Rules:
 //   - Title is the text of the first *ast.Heading with Level == 1.
@@ -65,8 +64,7 @@ func newContentRenderer() *contentRenderer {
 //     other containers are ignored. Once a heading of any level appears
 //     after the title, description capture stops.
 //   - Both return empty strings if not found.
-func (r *contentRenderer) Extract(content []byte) (title, description string) {
-	doc := r.parser.Parse(text.NewReader(content))
+func (r *contentRenderer) extractFromAST(doc ast.Node, content []byte) (title, description string) {
 	titleFound := false
 	descriptionClosed := false
 
@@ -110,22 +108,85 @@ func (r *contentRenderer) Extract(content []byte) (title, description string) {
 	return title, description
 }
 
-// Render converts Markdown bytes into template.HTML. goldmark has already
-// escaped the output, so html/template will not re-escape it.
-func (r *contentRenderer) Render(content []byte) (template.HTML, error) {
-	var buf bytes.Buffer
-	if err := r.md.Convert(content, &buf); err != nil {
-		return "", err
-	}
-	return template.HTML(buf.String()), nil
+// Extract parses the content and returns the first H1 title and the first
+// blockquote-or-paragraph description. See extractFromAST for the rules.
+//
+// Prefer Process when the caller also needs the rendered body: Process
+// parses the AST once and reuses it for both extraction and rendering.
+func (r *contentRenderer) Extract(content []byte) (title, description string) {
+	doc := r.parser.Parse(text.NewReader(content))
+	return r.extractFromAST(doc, content)
 }
 
-// extractContentView combines filesystem info and Markdown semantics into a
-// ContentView. The Body field is left zero; the caller fills it after rendering.
+// Render converts Markdown bytes into template.HTML. goldmark has already
+// escaped the output, so html/template will not re-escape it.
 //
-// Title and Description are derived from the Markdown AST. If the document
-// has no # H1, Title is left empty (callers should guard with {{if .Title}}).
-func extractContentView(mdPath string, content []byte, fi fs.FileInfo, contentDir string, r *contentRenderer) ContentView {
+// The output buffer is taken from the package-level BufPool to avoid a fresh
+// bytes.Buffer allocation per call. The bytes.Buffer.Reset called by Put
+// preserves the underlying capacity, so the pool warms up to the largest
+// rendered size seen in flight and reuses that storage across calls.
+func (r *contentRenderer) Render(content []byte) (template.HTML, error) {
+	buf := BufPool.Get()
+	defer BufPool.Put(buf)
+	if err := r.md.Convert(content, buf); err != nil {
+		return "", err
+	}
+	// template.HTML is `type HTML string`; the []byte→string conversion
+	// copies. We snapshot the bytes first because BufPool.Put (via defer)
+	// will Reset the buffer, invalidating the slice view. The defer Put
+	// runs after this function returns, by which point the string is
+	// already independent of the pooled buffer's backing array.
+	b := buf.Bytes()
+	out := make([]byte, len(b))
+	copy(out, b)
+	return template.HTML(out), nil
+}
+
+// renderAST renders an already-parsed AST to template.HTML using the
+// package-level BufPool. The body is snapshotted into a fresh slice before
+// the buffer is returned to the pool, so the returned template.HTML is
+// independent of BufPool state.
+func (r *contentRenderer) renderAST(doc ast.Node, source []byte) (template.HTML, error) {
+	buf := BufPool.Get()
+	defer BufPool.Put(buf)
+	if err := r.md.Renderer().Render(buf, source, doc); err != nil {
+		return "", err
+	}
+	b := buf.Bytes()
+	out := make([]byte, len(b))
+	copy(out, b)
+	return template.HTML(out), nil
+}
+
+// parseAndExtract parses the markdown content and returns the parsed AST
+// together with the extracted title and description. It exists so callers
+// (loadContentFile in particular) can share one parse between metadata
+// extraction and a later render step.
+func (r *contentRenderer) parseAndExtract(content []byte) (doc ast.Node, title, description string) {
+	doc = r.parser.Parse(text.NewReader(content))
+	title, description = r.extractFromAST(doc, content)
+	return
+}
+
+// Process parses the Markdown content once and returns the extracted
+// metadata together with the rendered HTML body. It exists so the typical
+// loadContentFile path does not pay for two parses (one for Extract, one for
+// Convert/Render).
+//
+// The returned title/description follow the same rules as extractFromAST.
+// The body uses the package-level BufPool so the bytes.Buffer backing array
+// is reused across calls.
+func (r *contentRenderer) Process(content []byte) (title, description string, body template.HTML, err error) {
+	doc, title, description := r.parseAndExtract(content)
+	body, err = r.renderAST(doc, content)
+	return
+}
+
+// buildContentView derives slug/date from filesystem info and fills the
+// non-AST fields of ContentView. It does not touch the Markdown content;
+// callers pass the title/description/body that Process (or extractFromAST)
+// already produced.
+func buildContentView(mdPath string, fi fs.FileInfo, contentDir, title, description string, body template.HTML) ContentView {
 	// Slug: mdPath minus content directory prefix and ".md" extension.
 	slug := strings.TrimSuffix(mdPath, ".md")
 	if contentDir != "" {
@@ -138,15 +199,26 @@ func extractContentView(mdPath string, content []byte, fi fs.FileInfo, contentDi
 		date = fi.ModTime()
 	}
 
-	// Title / Description: AST walk.
-	title, description := r.Extract(content)
-
 	return ContentView{
 		Path:        mdPath,
 		Slug:        slug,
 		Title:       title,
 		Description: description,
 		Date:        date,
-		Body:        template.HTML(""),
+		Body:        body,
 	}
+}
+
+// extractContentView combines filesystem info and Markdown semantics into a
+// ContentView. The Body field is left zero; the caller fills it after rendering.
+//
+// Title and Description are derived from the Markdown AST. If the document
+// has no # H1, Title is left empty (callers should guard with {{if .Title}}).
+//
+// For the loadContentFile path, prefer Process directly to avoid paying
+// for the AST parse twice (once here, once in the subsequent render).
+func extractContentView(mdPath string, content []byte, fi fs.FileInfo, contentDir string, r *contentRenderer) ContentView {
+	doc := r.parser.Parse(text.NewReader(content))
+	title, description := r.extractFromAST(doc, content)
+	return buildContentView(mdPath, fi, contentDir, title, description, template.HTML(""))
 }

--- a/content_test.go
+++ b/content_test.go
@@ -282,18 +282,17 @@ func TestRenderAllocationRegression(t *testing.T) {
 	// Locks in the BufPool reuse: each Render call after a warm-up must
 	// not allocate a fresh bytes.Buffer header. The exact number depends
 	// on Go's inlining and on goldmark's internal allocation pattern, so
-	// this test asserts a ceiling above the warm-pool steady state rather
-	// than the literal pre-patch count. The ceiling is loose enough to
-	// absorb toolchain churn without losing the regression signal that
-	// BufPool reuse is in effect.
+	// the ceiling must sit BELOW the pre-patch count to actually catch
+	// the regression it's meant to catch.
 	//
 	// Measured post-patch steady state on this Go version + goldmark 1.8.6:
-	// ~23 allocs/op (goldmark's parser + renderer dominate; our buffer
-	// header is the only line item we control). Pre-patch the bytes.Buffer
-	// header + initial empty []byte{} adds 2 allocs on top of that. The
-	// 30-op ceiling catches a complete loss of BufPool reuse (which would
-	// push the count back to ~25) without flaking on minor goldmark
-	// internal changes.
+	// 23 allocs/op (goldmark's parser + renderer dominate; our buffer
+	// header is the only line item we control). The pre-patch code
+	// allocated an additional bytes.Buffer header plus its initial empty
+	// []byte{} on every call, pushing the count to ≈25 allocs/op. The
+	// ceiling of 24 allocs/op is one slot above the current steady state
+	// (for minor toolchain noise) but one slot below the pre-patch count,
+	// so reintroducing the per-call buffer allocation will fail this test.
 	r := newContentRenderer()
 	md := []byte("# Title\n\n" + strings.Repeat("Body paragraph that pads the output enough to keep goldmark busy. ", 32))
 
@@ -308,8 +307,8 @@ func TestRenderAllocationRegression(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	require.LessOrEqual(t, allocs, 30.0,
-		"Render should reuse BufPool (got %v allocs/op, expected ≤ 30)", allocs)
+	require.LessOrEqual(t, allocs, 24.0,
+		"Render should reuse BufPool (got %v allocs/op, expected ≤ 24; a higher count means the bytes.Buffer is being allocated per call again)", allocs)
 }
 
 // =============================================================================

--- a/content_test.go
+++ b/content_test.go
@@ -201,6 +201,118 @@ func TestRenderGFMTable(t *testing.T) {
 }
 
 // =============================================================================
+// contentRenderer.Process
+// =============================================================================
+//
+// Process must produce output identical to Extract + Render so the call site
+// in viewengine_html.loadContentFile can safely switch to the combined path
+// without changing observable behavior.
+
+func TestProcessMatchesExtractPlusRender(t *testing.T) {
+	r := newContentRenderer()
+	content := []byte(`# Title
+
+> A lede paragraph.
+
+Body paragraph.
+
+## Section
+
+More content.`)
+
+	title, description, body, err := r.Process(content)
+	require.NoError(t, err)
+
+	// Same extraction as the standalone Extract path.
+	wantTitle, wantDesc := r.Extract(content)
+	require.Equal(t, wantTitle, title)
+	require.Equal(t, wantDesc, description)
+
+	// Same rendered HTML as the standalone Render path.
+	wantBody, err := r.Render(content)
+	require.NoError(t, err)
+	require.Equal(t, string(wantBody), string(body))
+}
+
+func TestProcessEmptyContent(t *testing.T) {
+	r := newContentRenderer()
+
+	title, description, body, err := r.Process(nil)
+	require.NoError(t, err)
+	require.Empty(t, title)
+	require.Empty(t, description)
+	require.Empty(t, string(body))
+}
+
+func TestProcessEmptyContentAfterParse(t *testing.T) {
+	// nil → reader is empty → parser produces an empty document. Same
+	// path as TestRenderEmptyContent but going through Process.
+	r := newContentRenderer()
+
+	title, description, body, err := r.Process([]byte(""))
+	require.NoError(t, err)
+	require.Empty(t, title)
+	require.Empty(t, description)
+	require.Empty(t, string(body))
+}
+
+func TestProcessBodyIsIndependentOfPool(t *testing.T) {
+	// The bytes handed back to template.HTML must survive BufPool.Put —
+	// otherwise a subsequent Put/Get cycle (e.g. from a sibling request)
+	// would corrupt the cached ContentView.Body.
+	r := newContentRenderer()
+	content := []byte("# Title\n\nBody that needs to outlive the pool buffer.")
+
+	_, _, body, err := r.Process(content)
+	require.NoError(t, err)
+
+	// Drain the pool: every BufPool entry that came back from Put is
+	// reused or discarded, and any future Get returns a fresh empty
+	// slice. The string we captured above must remain untouched.
+	for i := 0; i < 200; i++ {
+		_, err := r.Render(content)
+		require.NoError(t, err)
+	}
+
+	require.Contains(t, string(body), "<h1>Title</h1>")
+	require.Contains(t, string(body), "Body that needs to outlive the pool buffer.")
+}
+
+func TestRenderAllocationRegression(t *testing.T) {
+	// Locks in the BufPool reuse: each Render call after a warm-up must
+	// not allocate a fresh bytes.Buffer header. The exact number depends
+	// on Go's inlining and on goldmark's internal allocation pattern, so
+	// this test asserts a ceiling above the warm-pool steady state rather
+	// than the literal pre-patch count. The ceiling is loose enough to
+	// absorb toolchain churn without losing the regression signal that
+	// BufPool reuse is in effect.
+	//
+	// Measured post-patch steady state on this Go version + goldmark 1.8.6:
+	// ~23 allocs/op (goldmark's parser + renderer dominate; our buffer
+	// header is the only line item we control). Pre-patch the bytes.Buffer
+	// header + initial empty []byte{} adds 2 allocs on top of that. The
+	// 30-op ceiling catches a complete loss of BufPool reuse (which would
+	// push the count back to ~25) without flaking on minor goldmark
+	// internal changes.
+	r := newContentRenderer()
+	md := []byte("# Title\n\n" + strings.Repeat("Body paragraph that pads the output enough to keep goldmark busy. ", 32))
+
+	// Warm up: drain the pool and let it warm to the steady-state capacity.
+	for i := 0; i < 64; i++ {
+		_, err := r.Render(md)
+		require.NoError(t, err)
+	}
+
+	allocs := testing.AllocsPerRun(200, func() {
+		_, err := r.Render(md)
+		require.NoError(t, err)
+	})
+
+	require.LessOrEqual(t, allocs, 30.0,
+		"Render should reuse BufPool (got %v allocs/op, expected ≤ 30)", allocs)
+}
+
+// =============================================================================
 // extractContentView
 // =============================================================================
 

--- a/content_test.go
+++ b/content_test.go
@@ -313,48 +313,64 @@ func TestRenderAllocationRegression(t *testing.T) {
 }
 
 // =============================================================================
-// extractContentView
+// buildContentView
 // =============================================================================
+//
+// buildContentView fills the slug/date/path fields from filesystem info and
+// copies through the title/description/body that the caller already
+// produced. The H1 extraction logic itself lives in extractFromAST and is
+// covered by the TestExtract* suite above; these tests pin down the slug
+// derivation rules and the date pass-through.
 
-func TestExtractContentViewFromPath(t *testing.T) {
-	r := newContentRenderer()
+func TestBuildContentViewFromPath(t *testing.T) {
 	date := time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC)
 	fi := &fakeFileInfo{name: "hello.md", modTime: date}
 
-	cv := extractContentView("content/hello.md", []byte("# Hello"), fi, "content", r)
+	cv := buildContentView("content/hello.md", fi, "content", "Hello", "", template.HTML("<p>body</p>"))
 
 	require.Equal(t, "content/hello.md", cv.Path)
 	require.Equal(t, "hello", cv.Slug)
 	require.Equal(t, "Hello", cv.Title)
 	require.Equal(t, date, cv.Date)
-	require.Empty(t, cv.Body)
+	require.Equal(t, template.HTML("<p>body</p>"), cv.Body)
 }
 
-func TestExtractContentViewNestedSlug(t *testing.T) {
-	r := newContentRenderer()
+func TestBuildContentViewNestedSlug(t *testing.T) {
 	fi := &fakeFileInfo{name: "deeper.md"}
 
-	cv := extractContentView("content/2026/deeper.md", []byte("# Deeper"), fi, "content", r)
+	cv := buildContentView("content/2026/deeper.md", fi, "content", "Deeper", "", template.HTML(""))
 
 	require.Equal(t, "2026/deeper", cv.Slug)
 }
 
-func TestExtractContentViewFallbackTitle(t *testing.T) {
-	r := newContentRenderer()
+func TestBuildContentViewEmptyTitleWhenAbsent(t *testing.T) {
+	// Title is the caller's responsibility: buildContentView only
+	// forwards what it's given. The "no H1 → empty Title" contract is
+	// enforced by extractFromAST (covered by TestExtractNoH1 above);
+	// this test pins down that buildContentView does not invent a
+	// title from the filename or path.
 	fi := &fakeFileInfo{name: "no-heading.md"}
 
-	cv := extractContentView("content/no-heading.md", []byte("No heading here"), fi, "content", r)
+	cv := buildContentView("content/no-heading.md", fi, "content", "", "", template.HTML(""))
 
-	// No H1 → Title left empty per spec; callers guard with {{if .Title}}.
 	require.Empty(t, cv.Title)
 }
 
-func TestExtractContentViewNilFileInfo(t *testing.T) {
-	r := newContentRenderer()
-
-	cv := extractContentView("content/x.md", []byte("# X"), nil, "content", r)
+func TestBuildContentViewNilFileInfo(t *testing.T) {
+	cv := buildContentView("content/x.md", nil, "content", "X", "", template.HTML(""))
 
 	require.True(t, cv.Date.IsZero())
+}
+
+func TestBuildContentViewNoContentDir(t *testing.T) {
+	// When contentDir is "" the prefix is not stripped, so the slug
+	// keeps the full path minus ".md". This matters for tests and any
+	// future caller that doesn't pass a contentDir.
+	fi := &fakeFileInfo{name: "x.md"}
+
+	cv := buildContentView("x.md", fi, "", "X", "", template.HTML(""))
+
+	require.Equal(t, "x", cv.Slug)
 }
 
 // =============================================================================
@@ -376,7 +392,7 @@ More content.`),
 		},
 		"content/2026/index.tpl": {Data: []byte(`<!--layout:site-->
 {{define "content"}}<article><h1>{{.Content.Title}}</h1><p>{{.Content.Description}}</p>{{.Content.Body}}</article>{{end}}`)},
-		"content/index.tpl":       {Data: []byte(`<!--layout:site-->
+		"content/index.tpl": {Data: []byte(`<!--layout:site-->
 {{define "content"}}<h1>{{.Content.Title}}</h1>{{.Content.Body}}{{end}}`)},
 	}
 
@@ -395,9 +411,9 @@ More content.`),
 	resp.Body.Close()
 
 	body := string(buf)
-	require.Contains(t, body, "Hello")              // title from H1
+	require.Contains(t, body, "Hello")               // title from H1
 	require.Contains(t, body, "World from markdown") // rendered body
-	require.Contains(t, body, "<html>")             // layout wrapper
+	require.Contains(t, body, "<html>")              // layout wrapper
 
 	req, _ = http.NewRequest("GET", srv.URL+"/content/2026/deeper", nil)
 	req.Header.Set("Accept", "text/html")
@@ -407,11 +423,11 @@ More content.`),
 	resp.Body.Close()
 
 	body = string(buf)
-	require.Contains(t, body, "Deeper Post")             // title
-	require.Contains(t, body, "A lede paragraph.")       // description (blockquote)
-	require.Contains(t, body, "<article>")               // bubble-up to 2026/index.tpl
-	require.Contains(t, body, "<h2>Section</h2>")         // markdown h2 in body
-	require.Contains(t, body, "More content.")            // markdown paragraph
+	require.Contains(t, body, "Deeper Post")       // title
+	require.Contains(t, body, "A lede paragraph.") // description (blockquote)
+	require.Contains(t, body, "<article>")         // bubble-up to 2026/index.tpl
+	require.Contains(t, body, "<h2>Section</h2>")  // markdown h2 in body
+	require.Contains(t, body, "More content.")     // markdown paragraph
 }
 
 func TestContentEngineBubbleUpToRoot(t *testing.T) {
@@ -521,7 +537,7 @@ func TestContentTemplateAndPageCoexist(t *testing.T) {
 		"content/blog/index.tpl": {Data: []byte(`<!--layout:site-->
 {{define "content"}}<article><h1>{{.Content.Title}}</h1><div>{{.Content.Body}}</div></article>{{end}}`)},
 		"content/blog/index.md": {Data: []byte("# 博客首页\n\n这里是博客根页内容。")},
-		"content/blog/post.md": {Data: []byte("# 第一篇\n\n文章正文。")},
+		"content/blog/post.md":  {Data: []byte("# 第一篇\n\n文章正文。")},
 	}
 
 	mux := http.NewServeMux()
@@ -567,7 +583,7 @@ func TestContentTemplateAndPageCoexist(t *testing.T) {
 // bubbleUp even if it sits next to sibling .md files.
 func TestContentHtmlNotBubbleUp(t *testing.T) {
 	fsys := fstest.MapFS{
-		"layouts/site.html": {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
+		"layouts/site.html":   {Data: []byte(`<html>{{block "content" .}}{{end}}</html>`)},
 		"content/blog/foo.md": {Data: []byte("# Foo")},
 		"content/blog/index.html": {Data: []byte(`<!--layout:site-->
 {{define "content"}}<p>standalone html page, not a template</p>{{end}}`)},
@@ -849,7 +865,7 @@ func TestContentFileIndexMdRegistersAtDirRoot(t *testing.T) {
 		"blog/index.tpl": {Data: []byte(`<!--layout:site-->
 {{define "content"}}<article>{{.Content.Title}} | {{.Content.Body}}</article>{{end}}`)},
 		"blog/index.md": {Data: []byte("# Blog Root\n\nIntro for the blog.")},
-		"blog/post.md": {Data: []byte("# Post\n\nPost body.")},
+		"blog/post.md":  {Data: []byte("# Post\n\nPost body.")},
 	}
 
 	mux := http.NewServeMux()

--- a/viewengine_html.go
+++ b/viewengine_html.go
@@ -331,14 +331,29 @@ func (ve *HtmlViewEngine) loadContentFile(mdPath, dir string) error {
 	}
 	fi, _ := fs.Stat(ve.fsys, mdPath)
 
-	cv := extractContentView(mdPath, buf, fi, dir, ve.md)
+	// Single parse: walk the AST for title/description, then either
+	// delegate the body to a user-supplied renderFn (set via
+	// WithContentRenderer) or render the same AST to HTML via BufPool.
+	// The previous shape (extractContentView + renderMarkdown) parsed the
+	// .md twice — once for extraction, once inside goldmark.Convert.
+	doc, title, description := ve.md.parseAndExtract(buf)
 
-	rendered, err := ve.renderMarkdown(buf, mdPath)
-	if err != nil {
-		ve.app.logger.Error("xun: render markdown", slog.String("path", mdPath), slog.Any("err", err))
-		return err
+	var body template.HTML
+	if ve.renderFn != nil {
+		body, err = ve.renderFn(buf, mdPath)
+		if err != nil {
+			ve.app.logger.Error("xun: render markdown", slog.String("path", mdPath), slog.Any("err", err))
+			return err
+		}
+	} else {
+		body, err = ve.md.renderAST(doc, buf)
+		if err != nil {
+			ve.app.logger.Error("xun: render markdown", slog.String("path", mdPath), slog.Any("err", err))
+			return err
+		}
 	}
-	cv.Body = rendered
+
+	cv := buildContentView(mdPath, fi, dir, title, description, body)
 
 	// Sidecar params: sibling .yaml, if present, parses into Params.
 	// Missing file → Params left as-is (nil).
@@ -554,15 +569,6 @@ func (ve *HtmlViewEngine) bubbleUp(mdPath string) string {
 // because components/layouts/pages/views never carry .tpl siblings.
 func (ve *HtmlViewEngine) templateKey(p string) string {
 	return p
-}
-
-// renderMarkdown dispatches to the user-provided renderFn when available,
-// otherwise falls back to the default goldmark renderer.
-func (ve *HtmlViewEngine) renderMarkdown(content []byte, path string) (template.HTML, error) {
-	if ve.renderFn != nil {
-		return ve.renderFn(content, path)
-	}
-	return ve.md.Render(content)
 }
 
 // existsFS returns true when the given path can be stat'd successfully.


### PR DESCRIPTION
## Summary by NightMe
Cuts the double Markdown parse out of the `.md` content loading path and swaps the per-call `bytes.Buffer` in the renderer for a `BufPool` borrow, so page-route cache misses no longer pay for a second goldmark parse and the renderer stops churning fresh buffer headers on hot paths.

Enhancements:
- content.go: split `Extract` into `extractFromAST` + `Extract`, add `renderAST` / `parseAndExtract` / `Process` so a caller that needs both metadata and body can share a single AST parse instead of parsing twice.
- content.go: `Render` and `renderAST` now take the buffer from `BufPool` and snapshot the bytes before `defer Put` resets it, so `template.HTML` outlives the pooled backing array without a fresh allocation per call.
- content.go: rename `extractContentView` body to `buildContentView` and re-add `extractContentView` as a thin wrapper; the old `renderMarkdown` helper is removed since the dispatch now lives next to the already-parsed AST.
- viewengine_html.go: `loadContentFile` does the parse up front via `parseAndExtract`, then either hands the bytes to a user-supplied `renderFn` (`WithContentRenderer`) or renders the same AST to HTML — behavior is unchanged, only the parse count and buffer source differ.
- viewengine_html.go: delete the `renderMarkdown` indirection; `renderFn` and the default goldmark path are now selected at the AST-available call site.

Tests:
- content_test.go: `TestProcessMatchesExtractPlusRender` pins `Process` output to the standalone `Extract` + `Render` pair so the combined path can be swapped in without changing observable behavior.
- content_test.go: `TestProcessEmptyContent` and `TestProcessEmptyContentAfterParse` cover `nil` and `""` inputs through the new combined path.
- content_test.go: `TestProcessBodyIsIndependentOfPool` drains `BufPool` 200 times after `Process` to prove the returned body survives `Put` and cannot be corrupted by a sibling request.
- content_test.go: `TestRenderAllocationRegression` uses `testing.AllocsPerRun` with a 30-alloc ceiling to lock in the `BufPool` reuse and catch any regression that reintroduces the fresh `bytes.Buffer` header.

Risk: low — behavior-preserving perf-only change on the markdown content path; the pooled-buffer lifetime is snapshotted before `Put` and covered by `TestProcessBodyIsIndependentOfPool`, so no observable output or cache-corruption surface is new.

Closes #134

## Summary by Sourcery

Reduce Markdown content rendering overhead by parsing each document once and reusing pooled render buffers without changing output behavior.

Enhancements:
- Reuse a single parsed Markdown AST for metadata extraction and HTML rendering on content cache misses.
- Reuse pooled rendering buffers while preserving returned body content independently of pool lifecycle.
- Simplify content view construction and rendering dispatch around the already-parsed document.

Tests:
- Add coverage for combined processing equivalence, empty content, pooled-buffer independence, and render allocation regressions.