### PR TITLE
fix(viewengine): close probe fs.File in StaticViewEngine.Load

### DIFF
--- a/option.go
+++ b/option.go
@@ -69,6 +69,19 @@ func WithWatch() Option {
 }
 
 // WithFsys sets the fs.FS for the App. If not set, Page Router is disabled.
+//
+// fsys is retained by the App for its full lifetime: stored on app.fsys and
+// referenced by every FileViewer registered during New (each viewer opens
+// fsys again per request). When WithWatch is set, the watcher also keeps a
+// reference for change events. WithFsys must therefore point at an fs.FS that
+// remains valid until App.Close — closing fsys after New will surface as 404s
+// or panics on subsequent requests.
+//
+// StaticViewEngine additionally opens fsys at "." exactly once during New, as
+// a probe to detect whether fsys is backed by embed.FS (so ETags can be
+// computed at registration time instead of per request). That probe fs.File is
+// closed before StaticViewEngine.Load returns, so no descriptor is leaked from
+// the probe itself; the underlying fsys is unaffected by the probe.
 func WithFsys(fsys fs.FS) Option {
 	return func(app *App) {
 		app.fsys = fsys

--- a/testdata/embed_helper.txt
+++ b/testdata/embed_helper.txt
@@ -1,0 +1,2 @@
+// Package-level embed helper for viewengine_static_test.go.
+// Exists only to make the testdata/ directory a valid //go:embed source.

--- a/viewengine_static.go
+++ b/viewengine_static.go
@@ -28,6 +28,7 @@ func (ve *StaticViewEngine) Load(fsys fs.FS, app *App) {
 		if t.Kind() == reflect.Ptr { //nolint: govet
 			ve.isEmbedFsys = t.Elem().PkgPath() == "embed"
 		}
+		root.Close() // nolint: errcheck
 	}
 
 	fs.WalkDir(fsys, "public", func(path string, d fs.DirEntry, err error) error { // nolint: errcheck

--- a/viewengine_static_test.go
+++ b/viewengine_static_test.go
@@ -1,0 +1,88 @@
+package xun
+
+import (
+	"embed"
+	"io/fs"
+	"sync/atomic"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed testdata/embed_helper.txt
+var staticEmbedFS embed.FS
+
+// closeCountingFS wraps an fs.FS so the file returned from Open(".")
+// records whether Close was called. Other Open paths pass through untouched.
+type closeCountingFS struct {
+	fsys   fs.FS
+	closes atomic.Int32
+}
+
+func (f *closeCountingFS) Open(name string) (fs.File, error) {
+	file, err := f.fsys.Open(name)
+	if err != nil || name != "." {
+		return file, err
+	}
+	return &closeCountingFile{File: file, closes: &f.closes}, nil
+}
+
+type closeCountingFile struct {
+	fs.File
+	closes *atomic.Int32
+}
+
+func (f *closeCountingFile) Close() error {
+	f.closes.Add(1)
+	return f.File.Close()
+}
+
+// TestStaticViewEngine_ProbeFileClosed is the regression test for the
+// "root.Close() is missing" leak in StaticViewEngine.Load: the probe handle
+// obtained from fsys.Open(".") must be closed before Load returns.
+//
+// https://github.com/yaitoo/xun/issues/135
+func TestStaticViewEngine_ProbeFileClosed(t *testing.T) {
+	fsys := &closeCountingFS{fsys: fstest.MapFS{}}
+
+	ve := &StaticViewEngine{}
+	ve.Load(fsys, nil)
+
+	require.Equal(t, int32(1), fsys.closes.Load(),
+		"expected the probe fs.File from fsys.Open(\".\") to be closed exactly once")
+}
+
+// TestStaticViewEngine_DetectsEmbedViaSubFS guards the canonical production
+// wiring shown in README.md (fs.Sub over embed.FS). The current probe
+// (fsys.Open(".")) happens to walk past fs.subFS because subFS.Open
+// delegates to the parent embed.FS, returning *embed.openFile whose
+// PkgPath is "embed". Any future "reflect on fsys instead" refactor must
+// preserve that behaviour or it will silently disable ETags for the
+// documented production wiring.
+//
+// https://github.com/yaitoo/xun/issues/135
+func TestStaticViewEngine_DetectsEmbedViaSubFS(t *testing.T) {
+	sub, err := fs.Sub(staticEmbedFS, "testdata")
+	require.NoError(t, err)
+
+	ve := &StaticViewEngine{}
+	ve.Load(sub, nil)
+
+	require.True(t, ve.isEmbedFsys,
+		"expected isEmbedFsys=true for fs.Sub(embed.FS, ...) (canonical production wiring)")
+}
+
+// TestStaticViewEngine_NonEmbedNotDetected is the symmetric guard: a
+// non-embed fs.FS (fstest.MapFS here) must not be misclassified as embed.
+// A regression here would also leak fd-relative issues (every non-embed
+// load would now eagerly hash every public file at registration time).
+func TestStaticViewEngine_NonEmbedNotDetected(t *testing.T) {
+	fsys := fstest.MapFS{}
+
+	ve := &StaticViewEngine{}
+	ve.Load(fsys, nil)
+
+	require.False(t, ve.isEmbedFsys,
+		"expected isEmbedFsys=false for fstest.MapFS")
+}


### PR DESCRIPTION
## Summary by NightMe
StaticViewEngine.Load opened fsys at "." to sniff embed.FS for ETag generation but never closed the returned fs.File, leaking a descriptor on every app startup; the probe is now closed before Load returns and the fsys lifetime contract on WithFsys is spelled out.

Bug Fixes:
- viewengine_static.go: the embed-sniff probe fs.File from fsys.Open(".") is now closed before Load returns, closing the fd leak on every app startup

Tests:
- viewengine_static_test.go: regression test pins the probe Close via a counting fs.FS wrapper, plus guards for the canonical fs.Sub(embed.FS, ...) wiring and its negative case (see Bug Fixes above for the fix it pins)
- testdata/embed_helper.txt: placeholder so //go:embed testdata/... resolves in the new test

Documentation:
- option.go: WithFsys doc-comment now spells out that fsys must remain valid until App.Close and that the probe descriptor is closed before Load returns (see Bug Fixes above)

Risk: low — one-line Close on a probe descriptor already released after sniffing, backed by a counting-fs regression test.

Closes #135

## Summary by Sourcery

Prevent StaticViewEngine startup probe descriptors from leaking while documenting filesystem lifetime requirements and protecting the behavior with regression tests.

Bug Fixes:
- Close the StaticViewEngine embed-detection probe file before returning from Load to prevent a file descriptor leak during application startup.

Enhancements:
- Clarify the WithFsys lifetime requirements and document the probe’s resource behavior.

Tests:
- Add regression coverage for probe-file closure and embed.FS detection through fs.Sub, including a non-embed guard.